### PR TITLE
pnr/nextpnr/ecp5: add macOS target

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -328,6 +328,19 @@ jobs:
           submodules: 'true'
       - uses: hdl/conda-ci@master
 
+  #73
+  nextpnr-ecp5-osx:
+    runs-on: "macos-latest"
+    needs: ["prjtrellis-osx", "symbiflow-yosys-3_2_1-osx", "symbiflow-yosys-3_3-osx"]
+    env:
+      PACKAGE: "pnr/nextpnr/ecp5"
+      OS_NAME: "osx"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - uses: hdl/conda-ci@master
+
   #24
   nextpnr-generic-linux:
     runs-on: "ubuntu-16.04"


### PR DESCRIPTION
PR changes:
- add OSX support for _nextpnr/ecp5_ package
- ~~add _DOT_ON_STDOUT_ functionality to avoid 10min timout from Travis~~

~~Marked as WIP due to _nextpnr/ecp5_ package hits 50min timeout on Travis for OSX.~~