### PR TITLE
WIP: add symbiflow-toolchain package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -271,6 +271,12 @@ jobs:
     after_success:
       - echo "Xilinx Vivado metapackages built for versions:" && cat $VERSIONS
 
+ # EDA Tools - Toolchains
+  - stage: "No dependencies"
+    os: linux
+    dist: xenial
+    env: PACKAGE=toolchain/symbiflow-toolchain
+
  # Move packages from the current label to main
   - stage: "Main label upload"
     os: linux

--- a/toolchain/symbiflow-toolchain/build.sh
+++ b/toolchain/symbiflow-toolchain/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ x"$TRAVIS" = xtrue ]; then
+	CPU_COUNT=2
+fi
+
+wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/presubmit/install/1049/20201123-030526/symbiflow-arch-defs-install-05bd35c7.tar.xz | tar -xJC ${PREFIX}

--- a/toolchain/symbiflow-toolchain/meta.yaml
+++ b/toolchain/symbiflow-toolchain/meta.yaml
@@ -1,0 +1,24 @@
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
+package:
+  name: prjxray-db
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/SymbiFlow/symbiflow-arch-defs.git
+  git_rev: master
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+about:
+  home: https://github.com/SymbiFlow/symbiflow-arch-defs
+  license: ISC
+  license_file: LICENSE
+  summary: 'FOSS architecture definitions of FPGA hardware useful for doing PnR device generation.'


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR adds the symbiflow-toolchain binaries from the packages generated by symbiflow-arch-defs.
Currently, a hardcoded link is provided for the binaries, hence the `WIP`.