### PR TITLE
Correct metapackages

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -18,7 +18,7 @@ on:
 env:
   ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
   ANACONDA_USER: ${{ secrets.ANACONDA_USER }}
-  NUM_OF_JOBS: 70
+  NUM_OF_JOBS: 71
 defaults:
   run:
     shell: bash
@@ -868,13 +868,29 @@ jobs:
       - uses: hdl/conda-ci@master
 
   #60
-  uhdm-integration-yosys-linux:
+  uhdm-integration-yosys-linux-py37:
     runs-on: "ubuntu-16.04"
-    needs: ["surelog-uhdm-linux-py37", "surelog-uhdm-linux-py38", "yosys-uhdm-linux-py37", "yosys-uhdm-linux-py38"]
+    needs: ["surelog-uhdm-linux-py37", "yosys-uhdm-linux-py37"]
     env:
       PACKAGE: "sim/uhdm-integration-yosys"
       USE_SYSTEM_GCC_VERSION: "9"
       OS_NAME: "linux"
+      PYTHON_VERSION: "3.7"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - uses: hdl/conda-ci@master
+
+  #71
+  uhdm-integration-yosys-linux-py38:
+    runs-on: "ubuntu-16.04"
+    needs: ["surelog-uhdm-linux-py38", "yosys-uhdm-linux-py38"]
+    env:
+      PACKAGE: "sim/uhdm-integration-yosys"
+      USE_SYSTEM_GCC_VERSION: "9"
+      OS_NAME: "linux"
+      PYTHON_VERSION: "3.8"
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -18,7 +18,7 @@ on:
 env:
   ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
   ANACONDA_USER: ${{ secrets.ANACONDA_USER }}
-  NUM_OF_JOBS: 69
+  NUM_OF_JOBS: 70
 defaults:
   run:
     shell: bash
@@ -838,13 +838,29 @@ jobs:
       - uses: hdl/conda-ci@master
 
   #59
-  uhdm-integration-verilator-linux:
+  uhdm-integration-verilator-linux-py37:
     runs-on: "ubuntu-16.04"
-    needs: ["surelog-uhdm-linux-py37", "surelog-uhdm-linux-py38", "verilator-uhdm-linux"]
+    needs: ["surelog-uhdm-linux-py37", "verilator-uhdm-linux"]
     env:
       PACKAGE: "sim/uhdm-integration-verilator"
       USE_SYSTEM_GCC_VERSION: "9"
       OS_NAME: "linux"
+      PYTHON_VERSION: "3.7"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+      - uses: hdl/conda-ci@master
+
+  #70
+  uhdm-integration-verilator-linux-py38:
+    runs-on: "ubuntu-16.04"
+    needs: ["surelog-uhdm-linux-py38", "verilator-uhdm-linux"]
+    env:
+      PACKAGE: "sim/uhdm-integration-verilator"
+      USE_SYSTEM_GCC_VERSION: "9"
+      OS_NAME: "linux"
+      PYTHON_VERSION: "3.8"
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -261,6 +261,8 @@ jobs:
 
   #19
   quicklogic-vtr-linux:
+    # Skip if token isn't available (cross-repository PRs mainly)
+    if: ${{ github.env.ANACONDA_TOKEN != '' }}
     runs-on: "ubuntu-16.04"
     needs: "vtr-linux"
     env:
@@ -274,6 +276,8 @@ jobs:
 
   #20
   quicklogic-vtr-gui-linux:
+    # Skip if token isn't available (cross-repository PRs mainly)
+    if: ${{ github.env.ANACONDA_TOKEN != '' }}
     runs-on: "ubuntu-16.04"
     needs: "vtr-gui-linux"
     env:
@@ -839,6 +843,8 @@ jobs:
 
   #59
   uhdm-integration-verilator-linux-py37:
+    # Skip if token isn't available (cross-repository PRs mainly)
+    if: ${{ github.env.ANACONDA_TOKEN != '' }}
     runs-on: "ubuntu-16.04"
     needs: ["surelog-uhdm-linux-py37", "verilator-uhdm-linux"]
     env:
@@ -854,6 +860,8 @@ jobs:
 
   #70
   uhdm-integration-verilator-linux-py38:
+    # Skip if token isn't available (cross-repository PRs mainly)
+    if: ${{ github.env.ANACONDA_TOKEN != '' }}
     runs-on: "ubuntu-16.04"
     needs: ["surelog-uhdm-linux-py38", "verilator-uhdm-linux"]
     env:
@@ -869,6 +877,8 @@ jobs:
 
   #60
   uhdm-integration-yosys-linux-py37:
+    # Skip if token isn't available (cross-repository PRs mainly)
+    if: ${{ github.env.ANACONDA_TOKEN != '' }}
     runs-on: "ubuntu-16.04"
     needs: ["surelog-uhdm-linux-py37", "yosys-uhdm-linux-py37"]
     env:
@@ -884,6 +894,8 @@ jobs:
 
   #71
   uhdm-integration-yosys-linux-py38:
+    # Skip if token isn't available (cross-repository PRs mainly)
+    if: ${{ github.env.ANACONDA_TOKEN != '' }}
     runs-on: "ubuntu-16.04"
     needs: ["surelog-uhdm-linux-py38", "yosys-uhdm-linux-py38"]
     env:

--- a/pnr/quicklogic-vtr-gui/meta.yaml
+++ b/pnr/quicklogic-vtr-gui/meta.yaml
@@ -1,8 +1,7 @@
-{% set ns = namespace(version='0.0', build_string='0') %}
+{% set ns = namespace(version='0.0') %}
 {% for package in resolved_packages('host') %}
   {% if package.startswith( 'vtr-gui ' ) %}
     {% set ns.version = package.split()[1] %}
-    {% set ns.build_string = package.split()[2] %}
   {% endif %}
 {% endfor %}
 
@@ -10,12 +9,12 @@ package:
   name: quicklogic-vtr-gui
   version: {{ ns.version }}
 build:
-  string: {{ ns.build_string }}
+  string: {{ DATE_STR }}
 requirements:
   host:
-    - vtr-gui
+    - vtr-gui=*={{ DATE_STR }}
   run:
-    - vtr-gui={{ ns.version }}={{ ns.build_string }}
+    - vtr-gui={{ ns.version }}={{ DATE_STR }}
 about:
   home: http://verilogtorouting.org/
   license: MIT

--- a/pnr/quicklogic-vtr/meta.yaml
+++ b/pnr/quicklogic-vtr/meta.yaml
@@ -1,8 +1,7 @@
-{% set ns = namespace(version='0.0', build_string='0') %}
+{% set ns = namespace(version='0.0') %}
 {% for package in resolved_packages('host') %}
   {% if package.startswith( 'vtr ' ) %}
     {% set ns.version = package.split()[1] %}
-    {% set ns.build_string = package.split()[2] %}
   {% endif %}
 {% endfor %}
 
@@ -10,12 +9,12 @@ package:
   name: quicklogic-vtr
   version: {{ ns.version }}
 build:
-  string: {{ ns.build_string }}
+  string: {{ DATE_STR }}
 requirements:
   host:
-    - vtr
+    - vtr=*={{ DATE_STR }}
   run:
-    - vtr={{ ns.version }}={{ ns.build_string }}
+    - vtr={{ ns.version }}={{ DATE_STR }}
 about:
   home: http://verilogtorouting.org/
   license: MIT

--- a/sim/uhdm-integration-verilator/condarc
+++ b/sim/uhdm-integration-verilator/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/sim/uhdm-integration-verilator/meta.yaml
+++ b/sim/uhdm-integration-verilator/meta.yaml
@@ -1,21 +1,27 @@
-# Use `conda-build-prepare` before building for a better version string.
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X.X', GIT_DESCRIBE_NUMBER|int,   GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set ns = namespace(surelog_version='0.0', verilator_version='0.0') %}
+{% for package in resolved_packages('host') %}
+  {% if package.startswith( 'surelog-uhdm ' ) %}
+    {% set ns.surelog_version = package.split()[1] %}
+  {% endif %}
+  {% if package.startswith( 'verilator-uhdm ' ) %}
+    {% set ns.verilator_version = package.split()[1] %}
+  {% endif %}
+{% endfor %}
+
+{% set python_version = PYTHON_VERSION | default('3.7') %}
+{% set py_suffix = 'py%s'|format(python_version|replace('.', '')) %}
 
 package:
   name: uhdm-integration-verilator
-  version: {{ version }}
-
-source:
-  git_rev: master
-  git_url: https://github.com/alainmarcel/uhdm-integration.git
+  version: {{ ns.verilator_version }}
 
 build:
-  number: {{ environ.get('DATE_NUM') }}
-  string: {{ environ.get('DATE_STR') }}
-  script_env:
-    - CI
+  string: {{ DATE_STR }}_{{ py_suffix }}
 
 requirements:
+  host:
+    - surelog-uhdm=*={{ DATE_STR }}_{{ py_suffix }}
+    - verilator-uhdm=*={{ DATE_STR }}
   run:
-    - surelog-uhdm
-    - verilator-uhdm
+    - surelog-uhdm={{ ns.surelog_version }}={{ DATE_STR }}_{{ py_suffix }}
+    - verilator-uhdm={{ ns.verilator_version }}={{ DATE_STR }}

--- a/sim/uhdm-integration-yosys/condarc
+++ b/sim/uhdm-integration-yosys/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/sim/uhdm-integration-yosys/meta.yaml
+++ b/sim/uhdm-integration-yosys/meta.yaml
@@ -1,21 +1,28 @@
-# Use `conda-build-prepare` before building for a better version string.
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X.X', GIT_DESCRIBE_NUMBER|int,   GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set ns = namespace(surelog_version='0.0', yosys_version='0.0') %}
+{% for package in resolved_packages('host') %}
+  {% if package.startswith( 'surelog-uhdm ' ) %}
+    {% set ns.surelog_version = package.split()[1] %}
+  {% endif %}
+  {% if package.startswith( 'yosys-uhdm ' ) %}
+    {% set ns.yosys_version = package.split()[1] %}
+  {% endif %}
+{% endfor %}
+
+{% set python_version = PYTHON_VERSION | default('3.7') %}
+{% set py_suffix = 'py%s'|format(python_version|replace('.', '')) %}
+{% set build_string = '%s_%s'|format(DATE_STR, py_suffix) %}
 
 package:
   name: uhdm-integration-yosys
-  version: {{ version }}
-
-source:
-  git_rev: master
-  git_url: https://github.com/alainmarcel/uhdm-integration.git
+  version: {{ ns.yosys_version }}
 
 build:
-  number: {{ environ.get('DATE_NUM') }}
-  string: {{ environ.get('DATE_STR') }}
-  script_env:
-    - CI
+  string: {{ build_string }}
 
 requirements:
+  host:
+    - surelog-uhdm=*={{ build_string }}
+    - yosys-uhdm=*={{ build_string }}
   run:
-    - surelog-uhdm
-    - yosys-uhdm
+    - surelog-uhdm={{ ns.surelog_version }}={{ build_string }}
+    - yosys-uhdm={{ ns.yosys_version }}={{ build_string }}


### PR DESCRIPTION
This PR makes all metapackages always tied precisely to the packages built in the same CI workflow. This is required to make locking such metapackages possible and making sense.

However, there is a slight downside. Building a metapackage now will never succeed in cross-repository PRs. There's no Anaconda token in such workflows so the dependencies aren't uploaded after building and Conda won't be able to find them building the metapackage.

Building these recipes was tested locally. Jobs building metapackages are expected to fail in this PR if everything works well.