### PR TITLE
Fix runtime dependencies for Verilator

### DIFF
--- a/sim/verilator/meta.yaml
+++ b/sim/verilator/meta.yaml
@@ -30,6 +30,11 @@ requirements:
     - bison
     - flex
     - zlib
+  run:
+    - {{ compiler('cxx') }}
+    - bison
+    - flex
+    - ncurses
 
 test:
   requires:


### PR DESCRIPTION
I have added the following required runtime dependiencies to Verilator: cxx, bison, flex and ncurses