### PR TITLE
Add periodic builds

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -7,6 +7,8 @@ on:
     branches: [ master ]
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 23 * * *' # run daily at 23:00 (UTC)
 env:
   ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
   ANACONDA_USER: ${{ secrets.ANACONDA_USER }}


### PR DESCRIPTION
The packages are usually built from their default branches (the version
is not frozen).

For now we only had builds triggered by changes in the repository with
the packages.

The tool repositories change independently of the conda package
repository.

Adding a periodic build allows us to keep the packages up to date
without the need to update this repo and without triggering anything
manually.