### PR TITLE
verilator-uhdm: build package with whole 'image' directory contents

### DIFF
--- a/sim/verilator-uhdm/build.sh
+++ b/sim/verilator-uhdm/build.sh
@@ -18,6 +18,7 @@ mkdir -p "$PREFIX/bin"
 sed -i 's/"verilator_bin"/"verilator_bin-uhdm"/g' image/bin/verilator
 sed -i 's/"verilator_bin_dbg"/"verilator_bin_dbg-uhdm"/g' image/bin/verilator
 
-cp "$SRC_DIR/image/bin/verilator" "$PREFIX/bin/verilator-uhdm"
-cp "$SRC_DIR/image/bin/verilator_bin" "$PREFIX/bin/verilator_bin-uhdm"
-cp "$SRC_DIR/image/bin/verilator_bin_dbg" "$PREFIX/bin/verilator_bin_dbg-uhdm"
+cp -r $SRC_DIR/image/* "$PREFIX/"
+mv "$PREFIX/bin/verilator" "$PREFIX/bin/verilator-uhdm"
+mv "$PREFIX/bin/verilator_bin" "$PREFIX/bin/verilator_bin-uhdm"
+mv "$PREFIX/bin/verilator_bin_dbg" "$PREFIX/bin/verilator_bin_dbg-uhdm"


### PR DESCRIPTION
Simulation test cases for verilator-uhdm in sv-tests are failing because of lacking verilator build results other than binaries as for e.g. `verilated.mk` file while using the verilator-uhdm conda package. This PR is fixing the package by including whole `image` directory contents just like in yosys-uhdm recipe: https://github.com/hdl/conda-eda/blob/master/syn/yosys-uhdm/build.sh#L20

Here is an example with mentioned failure: https://symbiflow.github.io/sv-tests-results/#UhdmVerilator|11.4.3|simple_plus_operator_sim
Error:
```
Vtop.mk:53: /home/runner/work/conda-eda/conda-eda/workdir/conda-env/conda-bld/verilator-uhdm_1614698043301/work/image/share/verilator/include/verilated.mk: No such file or directory
```

Signed-off-by: Paweł Czarnecki <pczarnecki@antmicro.com>