### PR TITLE
Fix tree sitter package

### DIFF
--- a/misc/tree-sitter-verilog/build.sh
+++ b/misc/tree-sitter-verilog/build.sh
@@ -7,6 +7,6 @@ npm install tree-sitter-cli
 
 ./node_modules/tree-sitter-cli/tree-sitter generate
 
-$PYTHON -m pip install --isolated tree_sitter
+$PYTHON -m pip install --isolated 'tree_sitter==0.2.2'
 $PYTHON -c "from tree_sitter import Language; Language.build_library(\"$PREFIX/lib/tree-sitter-verilog.so\", [\".\"])"
 $PYTHON -m pip uninstall -y tree_sitter


### PR DESCRIPTION
Tree sitter verilog breaks if latest tree_sitter is used, see:
https://github.com/SymbiFlow/sv-tests/pull/1379/checks?check_run_id=2046877086

This should fix the package.

Companion PR: https://github.com/SymbiFlow/sv-tests/pull/1382