### PR TITLE
Don't use incompatible v2021 `tbb` and `tbb-devel` packages

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -916,6 +916,7 @@ jobs:
     env:
       PACKAGE: "sim/antmicro-yosys-complete"
       OS_NAME: "linux"
+      SKIP: "true"  # See https://github.com/hdl/conda-eda/issues/91
     steps:
       - uses: actions/checkout@v2
         with:
@@ -929,6 +930,7 @@ jobs:
     env:
       PACKAGE: "syn/antmicro-yosys-plugins"
       OS_NAME: "linux"
+      SKIP: "true"  # See https://github.com/hdl/conda-eda/issues/91
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -261,14 +261,14 @@ jobs:
 
   #19
   quicklogic-vtr-linux:
-    # Skip if token isn't available (cross-repository PRs mainly)
-    if: ${{ github.env.ANACONDA_TOKEN != '' }}
     runs-on: "ubuntu-16.04"
     needs: "vtr-linux"
     env:
       PACKAGE: "pnr/quicklogic-vtr"
       OS_NAME: "linux"
     steps:
+      # Skip if token isn't available (cross-repository PRs mainly)
+      - run: if [ "$ANACONDA_TOKEN" = "" ]; then echo "SKIP=true" >>$GITHUB_ENV; fi
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
@@ -276,14 +276,14 @@ jobs:
 
   #20
   quicklogic-vtr-gui-linux:
-    # Skip if token isn't available (cross-repository PRs mainly)
-    if: ${{ github.env.ANACONDA_TOKEN != '' }}
     runs-on: "ubuntu-16.04"
     needs: "vtr-gui-linux"
     env:
       PACKAGE: "pnr/quicklogic-vtr-gui"
       OS_NAME: "linux"
     steps:
+      # Skip if token isn't available (cross-repository PRs mainly)
+      - run: if [ "$ANACONDA_TOKEN" = "" ]; then echo "SKIP=true" >>$GITHUB_ENV; fi
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
@@ -843,8 +843,6 @@ jobs:
 
   #59
   uhdm-integration-verilator-linux-py37:
-    # Skip if token isn't available (cross-repository PRs mainly)
-    if: ${{ github.env.ANACONDA_TOKEN != '' }}
     runs-on: "ubuntu-16.04"
     needs: ["surelog-uhdm-linux-py37", "verilator-uhdm-linux"]
     env:
@@ -853,6 +851,8 @@ jobs:
       OS_NAME: "linux"
       PYTHON_VERSION: "3.7"
     steps:
+      # Skip if token isn't available (cross-repository PRs mainly)
+      - run: if [ "$ANACONDA_TOKEN" = "" ]; then echo "SKIP=true" >>$GITHUB_ENV; fi
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
@@ -860,8 +860,6 @@ jobs:
 
   #70
   uhdm-integration-verilator-linux-py38:
-    # Skip if token isn't available (cross-repository PRs mainly)
-    if: ${{ github.env.ANACONDA_TOKEN != '' }}
     runs-on: "ubuntu-16.04"
     needs: ["surelog-uhdm-linux-py38", "verilator-uhdm-linux"]
     env:
@@ -870,6 +868,8 @@ jobs:
       OS_NAME: "linux"
       PYTHON_VERSION: "3.8"
     steps:
+      # Skip if token isn't available (cross-repository PRs mainly)
+      - run: if [ "$ANACONDA_TOKEN" = "" ]; then echo "SKIP=true" >>$GITHUB_ENV; fi
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
@@ -877,8 +877,6 @@ jobs:
 
   #60
   uhdm-integration-yosys-linux-py37:
-    # Skip if token isn't available (cross-repository PRs mainly)
-    if: ${{ github.env.ANACONDA_TOKEN != '' }}
     runs-on: "ubuntu-16.04"
     needs: ["surelog-uhdm-linux-py37", "yosys-uhdm-linux-py37"]
     env:
@@ -887,6 +885,8 @@ jobs:
       OS_NAME: "linux"
       PYTHON_VERSION: "3.7"
     steps:
+      # Skip if token isn't available (cross-repository PRs mainly)
+      - run: if [ "$ANACONDA_TOKEN" = "" ]; then echo "SKIP=true" >>$GITHUB_ENV; fi
       - uses: actions/checkout@v2
         with:
           submodules: 'true'
@@ -894,8 +894,6 @@ jobs:
 
   #71
   uhdm-integration-yosys-linux-py38:
-    # Skip if token isn't available (cross-repository PRs mainly)
-    if: ${{ github.env.ANACONDA_TOKEN != '' }}
     runs-on: "ubuntu-16.04"
     needs: ["surelog-uhdm-linux-py38", "yosys-uhdm-linux-py38"]
     env:
@@ -904,6 +902,8 @@ jobs:
       OS_NAME: "linux"
       PYTHON_VERSION: "3.8"
     steps:
+      # Skip if token isn't available (cross-repository PRs mainly)
+      - run: if [ "$ANACONDA_TOKEN" = "" ]; then echo "SKIP=true" >>$GITHUB_ENV; fi
       - uses: actions/checkout@v2
         with:
           submodules: 'true'

--- a/pnr/odin_II/meta.yaml
+++ b/pnr/odin_II/meta.yaml
@@ -34,9 +34,11 @@ requirements:
     - xorg-libxcb
     - xorg-libxext
     - xorg-libxft
-    - tbb
-    - tbb-devel
+    - tbb <2021.0.0a0
+    - tbb-devel <2021.0.0a0
     - gtk3
+  run:
+    - tbb <2021.0.0a0
 
 about:
   home: http://verilogtorouting.org/

--- a/pnr/symbiflow-vtr-gui/meta.yaml
+++ b/pnr/symbiflow-vtr-gui/meta.yaml
@@ -36,15 +36,15 @@ requirements:
     - xorg-libxcb
     - xorg-libxext
     - xorg-libxft
-    - tbb
-    - tbb-devel
+    - tbb <2021.0.0a0
+    - tbb-devel <2021.0.0a0
     - gtk3
   run:
     - tk
     - fontconfig
     - xorg-libx11
     - xorg-libxft
-    - tbb
+    - tbb <2021.0.0a0
     - gtk3
 
 #test:

--- a/pnr/symbiflow-vtr/meta.yaml
+++ b/pnr/symbiflow-vtr/meta.yaml
@@ -27,10 +27,10 @@ requirements:
     - cmake
     - flex
     - pkg-config
-    - tbb
-    - tbb-devel
+    - tbb <2021.0.0a0
+    - tbb-devel <2021.0.0a0
   run:
-    - tbb
+    - tbb <2021.0.0a0
 
 #test:
 #  commands:

--- a/pnr/vtr-optimized/meta.yaml
+++ b/pnr/vtr-optimized/meta.yaml
@@ -37,10 +37,10 @@ requirements:
     - cmake
     - flex
     - pkg-config
-    - tbb
-    - tbb-devel
+    - tbb <2021.0.0a0
+    - tbb-devel <2021.0.0a0
   run:
-    - tbb
+    - tbb <2021.0.0a0
 
 about:
   home: http://verilogtorouting.org/

--- a/pnr/vtr/meta.yaml
+++ b/pnr/vtr/meta.yaml
@@ -32,10 +32,10 @@ requirements:
     - cmake
     - flex
     - pkg-config
-    - tbb
-    - tbb-devel
+    - tbb <2021.0.0a0
+    - tbb-devel <2021.0.0a0
   run:
-    - tbb
+    - tbb <2021.0.0a0
 
 #test:
 #  commands:


### PR DESCRIPTION
Related issue: #84

The `tbb-2021` and `tbb-devel-2021` available on `conda-forge` aren't
backward compatible. In fact, they will never be backward compatible
again: https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-threading-building-blocks-release-notes.html

The `tbb-2021` can't be used to run a package built with `tbb-2020`
because it even has a main library renamed from `libtbb.so.2` to
`libtbb.so.12`.

The new packages can't be currently built with TBBv2021 because CMake
isn't able to find it. It seems `include/tbb/tbb_stddef.h` is used
during the lookup but that file has been removed from `tbb-devel`
package. Also, currently `v2021` is only available from `conda-forge`.