### PR TITLE
yosys-uhdm fix: Use some build requirements as the host ones instead

### DIFF
--- a/syn/yosys-uhdm/meta.yaml
+++ b/syn/yosys-uhdm/meta.yaml
@@ -25,16 +25,17 @@ requirements:
     # packages from the `defaults` channel (libgcc-ng/libstdcxx-ng).
     - {{ compiler('c') }} <9
     - {{ compiler('cxx') }} <9
-    - python {{ python_version }}
+    - bison
     - cmake
-    - pkg-config
-    - libuuid
-    - gperftools
     - flex
+    - libuuid
+    - pkg-config
+  host:
+    - python {{ python_version }}
+    - gperftools
     - libunwind
     - swig
     - ncurses
-    - bison
     - openjdk
   run:
     - python {{python_version}}


### PR DESCRIPTION
Not only it solves build conflicts, which roots I'm unable to pinpoint,
but it's also more appropriate than the previous requirements
arrangement.