### PR TITLE
Fix nextpnr interchange installed device

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -364,7 +364,6 @@ jobs:
   #72
   nextpnr-fpga_interchange-linux:
     runs-on: "ubuntu-16.04"
-    needs: ["symbiflow-yosys-3_2_1-linux", "symbiflow-yosys-3_3-linux"]
     env:
       PACKAGE: "pnr/nextpnr/fpga_interchange"
       OS_NAME: "linux"

--- a/pnr/nextpnr/fpga_interchange/build.sh
+++ b/pnr/nextpnr/fpga_interchange/build.sh
@@ -36,10 +36,13 @@ mkdir -p $CHIPDB_DIR
 mkdir -p $DEVICES_DIR
 
 # Compute chipdbs for nextpnr-fpga_interchange
+# TODO: change the <device>.device names as soon as more architectures are added.
+#       In fact, the `constraints-luts` nomenclature corresponds
+#       to the patches specifically applied to xc7 devices only.
 for device in $DEVICES; do
 	make chipdb-${device}-bin -j${CPU_COUNT}
-	cp `find -iname "chipdb-${device}.bin"` $CHIPDB_DIR
-	cp `find -name "*.device" | grep -v luts | grep -v constr` $DEVICES_DIR
+	cp `find -iname "chipdb-${device}.bin"` $CHIPDB_DIR/${device}.bin
+	cp `find -name "${device}_constraints-luts.device"` $DEVICES_DIR/${device}.device
 done
 
 make install

--- a/pnr/nextpnr/fpga_interchange/meta.yaml
+++ b/pnr/nextpnr/fpga_interchange/meta.yaml
@@ -62,7 +62,6 @@ requirements:
   run:
     - libboost {{ boost_version }}
     - py-boost {{ boost_version }}
-    - symbiflow-yosys
     - python
     - zlib
 


### PR DESCRIPTION
The installed devices do miss patches information, relevant for constraints and LUTs definition.

This PR installs the correct devices and also removes the symbiflow-yosys run dependency package which should not be needed.