### PR TITLE
nextpnr: interchange: install also BBASM tool

### DIFF
--- a/pnr/nextpnr/fpga_interchange/build.sh
+++ b/pnr/nextpnr/fpga_interchange/build.sh
@@ -43,3 +43,5 @@ for device in $DEVICES; do
 done
 
 make install
+
+cp bba/bbasm ${PREFIX}/bin

--- a/pnr/nextpnr/fpga_interchange/build.sh
+++ b/pnr/nextpnr/fpga_interchange/build.sh
@@ -9,6 +9,7 @@ export PYTHON_EXECUTABLE=`which python3`
 export PYTHON_INTERCHANGE_PATH=`realpath python-fpga-interchange`
 pushd $PYTHON_INTERCHANGE_PATH
 python3 -m pip install -e .
+python3 -m pip install git+https://github.com/capnproto/pycapnp.git
 popd
 
 # Prepare RapidWright dependency

--- a/pnr/nextpnr/fpga_interchange/condarc
+++ b/pnr/nextpnr/fpga_interchange/condarc
@@ -1,4 +1,3 @@
 channels:
   - defaults
   - litex-hub
-  - conda-forge

--- a/pnr/nextpnr/fpga_interchange/meta.yaml
+++ b/pnr/nextpnr/fpga_interchange/meta.yaml
@@ -58,7 +58,8 @@ requirements:
     # python-fpga-interchange dependencies
     - pip
     - pyyaml
-    - pycapnp
+    - pkgconfig
+    - Cython
   run:
     - libboost {{ boost_version }}
     - py-boost {{ boost_version }}


### PR DESCRIPTION
BBASM is required to produce the binary version of a `.bba` chip information database of nextpnr.

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>