### PR TITLE
Fix Arachne compilation failed by newest gcc

### DIFF
--- a/pnr/arachne/meta.yaml
+++ b/pnr/arachne/meta.yaml
@@ -19,8 +19,8 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
+    - {{ compiler('c') }} <8
+    - {{ compiler('cxx') }} <8
     - bison
     - flex
     - make


### PR DESCRIPTION
This sets the compiler version to be old enough not to complain about
some missing optimisation capabilities. Arachne isn't actively developed
anyway.