### PR TITLE
nextpnr: Fix macOS issues and partly Windows

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -683,12 +683,12 @@ jobs:
 
   #47
   nextpnr-ice40-windows:
-    runs-on: "windows-latest"
+    runs-on: "windows-2016"
     needs: ["icestorm-windows"] 
     env:
       PACKAGE: "pnr/nextpnr/ice40"
       OS_NAME: "windows"
-      SKIP: "true" # Uses symbiflow-yosys (not built for windows)
+      SKIP: "true"  # See: https://github.com/hdl/conda-eda/issues/120
     steps:
       - uses: actions/checkout@v2
         with:
@@ -697,11 +697,11 @@ jobs:
 
   #48
   nextpnr-generic-windows:
-    runs-on: "windows-latest"
+    runs-on: "windows-2016"
     env:
       PACKAGE: "pnr/nextpnr/generic"
       OS_NAME: "windows"
-      SKIP: "true" # Uses symbiflow-yosys (not built for windows)
+      SKIP: "true"  # See: https://github.com/hdl/conda-eda/issues/120
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -603,7 +603,6 @@ jobs:
     env:
       PACKAGE: "pnr/nextpnr/ice40"
       OS_NAME: "osx"
-      SKIP: "true"  # See https://github.com/hdl/conda-eda/issues/98
     steps:
       - uses: actions/checkout@v2
         with:
@@ -616,7 +615,6 @@ jobs:
     env:
       PACKAGE: "pnr/nextpnr/generic"
       OS_NAME: "osx"
-      SKIP: "true"  # See https://github.com/hdl/conda-eda/issues/98
     steps:
       - uses: actions/checkout@v2
         with:

--- a/pnr/nextpnr/generic/meta.yaml
+++ b/pnr/nextpnr/generic/meta.yaml
@@ -22,10 +22,8 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}    [not osx]
-    - {{ compiler('cxx') }}  [not osx]
-    - clang_osx-64 4.0       [osx]
-    - clangxx_osx-64 4.0     [osx]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - m2-base    [win]
     - fontconfig [not win]
     - make       [not win]

--- a/pnr/nextpnr/ice40/meta.yaml
+++ b/pnr/nextpnr/ice40/meta.yaml
@@ -22,10 +22,8 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}       [not osx]
-    - {{ compiler('cxx') }}     [not osx]
-    - {{ compiler('c') }} 4.0   [osx]
-    - {{ compiler('cxx') }} 4.0 [osx]
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - m2-base    [win]
     - fontconfig [not win]
     - make       [not win]


### PR DESCRIPTION
macOS issues are fully fixed by raising compiler restriction that was once required to build these packages.

After solving one problem on Windows another came up so the specific issue was created for it: https://github.com/hdl/conda-eda/issues/120 .