### PR TITLE
symbiflow-vtr-gui: Stick to GCC <11

### DIFF
--- a/pnr/symbiflow-vtr-gui/meta.yaml
+++ b/pnr/symbiflow-vtr-gui/meta.yaml
@@ -19,8 +19,8 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
+    - {{ compiler('c') }} <11
+    - {{ compiler('cxx') }} <11
     - make
   host:
     - bison


### PR DESCRIPTION
Tool's build scripts haven't been adapted to the latest GCC yet.

Co-authored by: Maciej Dudek <mdudek@antmicro.com>