### PR TITLE
symbiflow-vtr-gui; odin_ii: pin libxml2 version

### DIFF
--- a/pnr/odin_II/meta.yaml
+++ b/pnr/odin_II/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
+    - libxml2 >2.9.9
     - bison
     - cmake
     - flex

--- a/pnr/symbiflow-vtr-gui/meta.yaml
+++ b/pnr/symbiflow-vtr-gui/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - {{ compiler('cxx') }} <11
     - make
   host:
+    - libxml2 >2.9.9
     - bison
     - cmake
     - flex


### PR DESCRIPTION
This commit fixes incompatibility of libxml2 with used compiler

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>