### PR TITLE
yosys-uhdm: fix missing libffi in host

### DIFF
--- a/syn/yosys-uhdm/meta.yaml
+++ b/syn/yosys-uhdm/meta.yaml
@@ -33,6 +33,7 @@ requirements:
   host:
     - python {{ python_version }}
     - libuuid
+    - libffi
     - gperftools
     - swig
     - ncurses
@@ -41,7 +42,6 @@ requirements:
     - python {{python_version}}
     - ncurses
     - readline
-    - libffi
     - gperftools
 
 test:


### PR DESCRIPTION
This PR fixes: ``libffi.so.7: cannot open shared object file: No such file or directory``: https://github.com/chipsalliance/sv-tests/issues/1758