### PR TITLE
Fix building uhdm plugin

### DIFF
--- a/syn/symbiflow-yosys-plugins/build.sh
+++ b/syn/symbiflow-yosys-plugins/build.sh
@@ -7,4 +7,4 @@ which pkg-config
 
 echo "PREFIX := $PREFIX" >> Makefile.conf
 
-make install -j$CPU_COUNT
+make UHDM_INSTALL_DIR=$PREFIX BUILD_UPSTREAM=1 install -j$CPU_COUNT

--- a/syn/symbiflow-yosys-plugins/fix_flags.patch
+++ b/syn/symbiflow-yosys-plugins/fix_flags.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile_plugin.common b/Makefile_plugin.common
-index ac9ae9b..516b3fb 100644
+index 0870f21..ff7e178 100644
 --- a/Makefile_plugin.common
 +++ b/Makefile_plugin.common
-@@ -47,12 +47,12 @@ ifeq (,$(wildcard $(YOSYS_CONFIG)))
+@@ -47,13 +47,13 @@ ifeq (,$(wildcard $(YOSYS_CONFIG)))
  $(error "Didn't find 'yosys-config' under '$(YOSYS_PATH)'")
  endif
  
@@ -12,12 +12,14 @@ index ac9ae9b..516b3fb 100644
 -LDLIBS ?= $(shell $(YOSYS_CONFIG) --ldlibs)
 -PLUGINS_DIR ?= $(shell $(YOSYS_CONFIG) --datdir)/plugins
 -DATA_DIR ?= $(shell $(YOSYS_CONFIG) --datdir)
+-EXTRA_FLAGS ?=
 +CXX = $(shell $(YOSYS_CONFIG) --cxx)
 +CXXFLAGS = $(shell $(YOSYS_CONFIG) --cxxflags) #-DSDC_DEBUG
 +LDFLAGS = $(shell $(YOSYS_CONFIG) --ldflags)
 +LDLIBS = $(shell $(YOSYS_CONFIG) --ldlibs)
 +PLUGINS_DIR = $(shell $(YOSYS_CONFIG) --datdir)/plugins
 +DATA_DIR = $(shell $(YOSYS_CONFIG) --datdir)
++EXTRA_FLAGS =
  
  OBJS := $(SOURCES:cc=o)
  

--- a/syn/symbiflow-yosys-plugins/meta.yaml
+++ b/syn/symbiflow-yosys-plugins/meta.yaml
@@ -24,8 +24,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - make
-  host:
     - pkg-config
+  host:
     - readline
     - bison
     - tk
@@ -33,6 +33,13 @@ requirements:
     - flex
     - iverilog
     - yosys
+    - surelog
   run:
     - yosys
+    - surelog
 
+test:
+    commands:
+        - yosys --version
+        - surelog --version
+        - yosys -p "plugin -i uhdm"

--- a/syn/yosys-plugins-symbiflow/build.sh
+++ b/syn/yosys-plugins-symbiflow/build.sh
@@ -7,4 +7,4 @@ which pkg-config
 
 echo "PREFIX := $PREFIX" >> Makefile.conf
 
-make install -j$CPU_COUNT
+make UHDM_INSTALL_DIR=$PREFIX BUILD_UPSTREAM=1 install -j$CPU_COUNT

--- a/syn/yosys-plugins-symbiflow/fix_flags.patch
+++ b/syn/yosys-plugins-symbiflow/fix_flags.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile_plugin.common b/Makefile_plugin.common
-index ac9ae9b..516b3fb 100644
+index 0870f21..ff7e178 100644
 --- a/Makefile_plugin.common
 +++ b/Makefile_plugin.common
-@@ -47,12 +47,12 @@ ifeq (,$(wildcard $(YOSYS_CONFIG)))
+@@ -47,13 +47,13 @@ ifeq (,$(wildcard $(YOSYS_CONFIG)))
  $(error "Didn't find 'yosys-config' under '$(YOSYS_PATH)'")
  endif
  
@@ -12,12 +12,14 @@ index ac9ae9b..516b3fb 100644
 -LDLIBS ?= $(shell $(YOSYS_CONFIG) --ldlibs)
 -PLUGINS_DIR ?= $(shell $(YOSYS_CONFIG) --datdir)/plugins
 -DATA_DIR ?= $(shell $(YOSYS_CONFIG) --datdir)
+-EXTRA_FLAGS ?=
 +CXX = $(shell $(YOSYS_CONFIG) --cxx)
 +CXXFLAGS = $(shell $(YOSYS_CONFIG) --cxxflags) #-DSDC_DEBUG
 +LDFLAGS = $(shell $(YOSYS_CONFIG) --ldflags)
 +LDLIBS = $(shell $(YOSYS_CONFIG) --ldlibs)
 +PLUGINS_DIR = $(shell $(YOSYS_CONFIG) --datdir)/plugins
 +DATA_DIR = $(shell $(YOSYS_CONFIG) --datdir)
++EXTRA_FLAGS =
  
  OBJS := $(SOURCES:cc=o)
  

--- a/syn/yosys-plugins-symbiflow/meta.yaml
+++ b/syn/yosys-plugins-symbiflow/meta.yaml
@@ -24,8 +24,9 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - make
-  host:
     - pkg-config
+  host:
+    - surelog
     - readline
     - bison
     - tk
@@ -35,4 +36,10 @@ requirements:
     - yosys
   run:
     - yosys
+    - surelog
 
+test:
+    commands:
+        - yosys --version
+        - surelog --version
+        - yosys -p "plugin -i uhdm"

--- a/syn/yosys-uhdm/uhdm-plugin.patch
+++ b/syn/yosys-uhdm/uhdm-plugin.patch
@@ -1,16 +1,19 @@
 diff --git a/yosys-symbiflow-plugins/Makefile_plugin.common b/yosys-symbiflow-plugins/Makefile_plugin.common
-index d96d186..decc0c3 100644
+index 0870f21..1cade4a 100644
 --- a/yosys-symbiflow-plugins/Makefile_plugin.common
 +++ b/yosys-symbiflow-plugins/Makefile_plugin.common
-@@ -39,20 +39,20 @@
+@@ -38,22 +38,22 @@
+ # |-- example2-plugin
  # |-- ...
  
- # Either find yosys in system and use its path or use the given path
+-# Either find yosys in system and use its path or use the given path
 -YOSYS_PATH ?= $(realpath $(dir $(shell which yosys))/..)
++# Either find uhdm-yosys in system and use its path or use the given path
 +YOSYS_PATH ?= $(realpath $(dir $(shell which uhdm-yosys))/..)
  
- # Find yosys-config, throw an error if not found
+-# Find yosys-config, throw an error if not found
 -YOSYS_CONFIG ?= $(YOSYS_PATH)/bin/yosys-config
++# Find uhdm-yosys-config, throw an error if not found
 +YOSYS_CONFIG ?= $(YOSYS_PATH)/bin/uhdm-yosys-config
  ifeq (,$(wildcard $(YOSYS_CONFIG)))
 -$(error "Didn't find 'yosys-config' under '$(YOSYS_PATH)'")
@@ -23,28 +26,33 @@ index d96d186..decc0c3 100644
 -LDLIBS ?= $(shell $(YOSYS_CONFIG) --ldlibs)
 -PLUGINS_DIR ?= $(shell $(YOSYS_CONFIG) --datdir)/plugins
 -DATA_DIR ?= $(shell $(YOSYS_CONFIG) --datdir)
+-EXTRA_FLAGS ?=
 +CXX = $(shell $(YOSYS_CONFIG) --cxx)
 +CXXFLAGS = $(shell $(YOSYS_CONFIG) --cxxflags) #-DSDC_DEBUG
 +LDFLAGS = $(shell $(YOSYS_CONFIG) --ldflags)
 +LDLIBS = $(shell $(YOSYS_CONFIG) --ldlibs)
 +PLUGINS_DIR = $(shell $(YOSYS_CONFIG) --datdir)/plugins
 +DATA_DIR = $(shell $(YOSYS_CONFIG) --datdir)
++EXTRA_FLAGS =
  
  OBJS := $(SOURCES:cc=o)
  
 diff --git a/yosys-symbiflow-plugins/Makefile_test.common b/yosys-symbiflow-plugins/Makefile_test.common
-index 1490199..15fd2ac 100644
+index 1490199..0b5c750 100644
 --- a/yosys-symbiflow-plugins/Makefile_test.common
 +++ b/yosys-symbiflow-plugins/Makefile_test.common
-@@ -15,20 +15,20 @@
+@@ -14,21 +14,21 @@
+ # test2_verify = $(call diff_test,test2,ext)
  #
  
- # Either find yosys in system and use its path or use the given path
+-# Either find yosys in system and use its path or use the given path
 -YOSYS_PATH ?= $(realpath $(dir $(shell which yosys))/..)
++# Either find uhdm-yosys in system and use its path or use the given path
 +YOSYS_PATH ?= $(realpath $(dir $(shell which uhdm-yosys))/..)
  
- # Find yosys-config, throw an error if not found
+-# Find yosys-config, throw an error if not found
 -YOSYS_CONFIG = $(YOSYS_PATH)/bin/yosys-config
++# Find uhdm-yosys-config, throw an error if not found
 +YOSYS_CONFIG = $(YOSYS_PATH)/bin/uhdm-yosys-config
  ifeq (,$(wildcard $(YOSYS_CONFIG)))
 -$(error "Didn't find 'yosys-config' under '$(YOSYS_PATH)'")
@@ -66,3 +74,12 @@ index 1490199..15fd2ac 100644
  
  define test_tpl =
  $(1): $(1)/ok
+@@ -49,7 +49,7 @@ $(1)/ok: $(1)/$(1).v
+ 	echo "source $(TEST_UTILS)" > run-$(1).tcl ;\
+ 	echo "source $(1).tcl" >> run-$(1).tcl ;\
+ 	DESIGN_TOP=$(1) TEST_OUTPUT_PREFIX=./ \
+-	yosys -c "run-$(1).tcl" -q -q -l $(1).log; \
++	uhdm-yosys -c "run-$(1).tcl" -q -q -l $(1).log; \
+ 	RETVAL=$$$$?; \
+ 	rm -f run-$(1).tcl; \
+ 	if [ ! -z "$$($(1)_negative)" ] && [ $$($(1)_negative) -eq 1 ]; then \

--- a/syn/yosys-uhdm/uhdm-plugin.patch
+++ b/syn/yosys-uhdm/uhdm-plugin.patch
@@ -1,45 +1,67 @@
 diff --git a/yosys-symbiflow-plugins/Makefile_plugin.common b/yosys-symbiflow-plugins/Makefile_plugin.common
-index 5e0a244..d06d555 100644
+index d96d186..decc0c3 100644
 --- a/yosys-symbiflow-plugins/Makefile_plugin.common
 +++ b/yosys-symbiflow-plugins/Makefile_plugin.common
-@@ -37,12 +37,12 @@
- # |       |   |-- ...
- # |-- example2-plugin
+@@ -39,20 +39,20 @@
  # |-- ...
--CXX ?= $(shell yosys-config --cxx)
--CXXFLAGS ?= $(shell yosys-config --cxxflags) #-DSDC_DEBUG
--LDFLAGS ?= $(shell yosys-config --ldflags)
--LDLIBS ?= $(shell yosys-config --ldlibs)
--PLUGINS_DIR ?= $(shell yosys-config --datdir)/plugins
--DATA_DIR ?= $(shell yosys-config --datdir)
-+CXX = $(shell uhdm-yosys-config --cxx)
-+CXXFLAGS = $(shell uhdm-yosys-config --cxxflags) #-DSDC_DEBUG
-+LDFLAGS = $(shell uhdm-yosys-config --ldflags)
-+LDLIBS = $(shell uhdm-yosys-config --ldlibs)
-+PLUGINS_DIR = $(shell uhdm-yosys-config --datdir)/plugins
-+DATA_DIR = $(shell uhdm-yosys-config --datdir)
+ 
+ # Either find yosys in system and use its path or use the given path
+-YOSYS_PATH ?= $(realpath $(dir $(shell which yosys))/..)
++YOSYS_PATH ?= $(realpath $(dir $(shell which uhdm-yosys))/..)
+ 
+ # Find yosys-config, throw an error if not found
+-YOSYS_CONFIG ?= $(YOSYS_PATH)/bin/yosys-config
++YOSYS_CONFIG ?= $(YOSYS_PATH)/bin/uhdm-yosys-config
+ ifeq (,$(wildcard $(YOSYS_CONFIG)))
+-$(error "Didn't find 'yosys-config' under '$(YOSYS_PATH)'")
++$(error "Didn't find 'uhdm-yosys-config' under '$(YOSYS_PATH)'")
+ endif
+ 
+-CXX ?= $(shell $(YOSYS_CONFIG) --cxx)
+-CXXFLAGS ?= $(shell $(YOSYS_CONFIG) --cxxflags) #-DSDC_DEBUG
+-LDFLAGS ?= $(shell $(YOSYS_CONFIG) --ldflags)
+-LDLIBS ?= $(shell $(YOSYS_CONFIG) --ldlibs)
+-PLUGINS_DIR ?= $(shell $(YOSYS_CONFIG) --datdir)/plugins
+-DATA_DIR ?= $(shell $(YOSYS_CONFIG) --datdir)
++CXX = $(shell $(YOSYS_CONFIG) --cxx)
++CXXFLAGS = $(shell $(YOSYS_CONFIG) --cxxflags) #-DSDC_DEBUG
++LDFLAGS = $(shell $(YOSYS_CONFIG) --ldflags)
++LDLIBS = $(shell $(YOSYS_CONFIG) --ldlibs)
++PLUGINS_DIR = $(shell $(YOSYS_CONFIG) --datdir)/plugins
++DATA_DIR = $(shell $(YOSYS_CONFIG) --datdir)
  
  OBJS := $(SOURCES:cc=o)
  
 diff --git a/yosys-symbiflow-plugins/Makefile_test.common b/yosys-symbiflow-plugins/Makefile_test.common
-index d1c8789..3ca7481 100644
+index 1490199..15fd2ac 100644
 --- a/yosys-symbiflow-plugins/Makefile_test.common
 +++ b/yosys-symbiflow-plugins/Makefile_test.common
-@@ -13,12 +13,12 @@
- # test1_verify = $(call diff_test,test1,ext) && test $$(grep "PASS" test1/test1.txt | wc -l) -eq 2
- # test2_verify = $(call diff_test,test2,ext)
+@@ -15,20 +15,20 @@
  #
+ 
+ # Either find yosys in system and use its path or use the given path
+-YOSYS_PATH ?= $(realpath $(dir $(shell which yosys))/..)
++YOSYS_PATH ?= $(realpath $(dir $(shell which uhdm-yosys))/..)
+ 
+ # Find yosys-config, throw an error if not found
+-YOSYS_CONFIG = $(YOSYS_PATH)/bin/yosys-config
++YOSYS_CONFIG = $(YOSYS_PATH)/bin/uhdm-yosys-config
+ ifeq (,$(wildcard $(YOSYS_CONFIG)))
+-$(error "Didn't find 'yosys-config' under '$(YOSYS_PATH)'")
++$(error "Didn't find 'uhdm-yosys-config' under '$(YOSYS_PATH)'")
+ endif
+ 
 -GTEST_DIR ?= ../../third_party/googletest/googletest
--CXX ?= $(shell yosys-config --cxx)
--CXXFLAGS ?= $(shell yosys-config --cxxflags) -I.. -I$(GTEST_DIR)/include
--LDLIBS ?= $(shell yosys-config --ldlibs) -L$(GTEST_DIR)/build/lib -lgtest -lgtest_main -lpthread
--LDFLAGS ?= $(shell yosys-config --ldflags)
+-CXX ?= $(shell $(YOSYS_CONFIG) --cxx)
+-CXXFLAGS ?= $(shell $(YOSYS_CONFIG) --cxxflags) -I.. -I$(GTEST_DIR)/include
+-LDLIBS ?= $(shell $(YOSYS_CONFIG) --ldlibs) -L$(GTEST_DIR)/build/lib -lgtest -lgtest_main -lpthread
+-LDFLAGS ?= $(shell $(YOSYS_CONFIG) --ldflags)
 -TEST_UTILS ?= ../../../test-utils/test-utils.tcl
 +GTEST_DIR = ../../third_party/googletest/googletest
-+CXX = $(shell uhdm-yosys-config --cxx)
-+CXXFLAGS = $(shell uhdm-yosys-config --cxxflags) -I.. -I$(GTEST_DIR)/include
-+LDLIBS = $(shell uhdm-yosys-config --ldlibs) -L$(GTEST_DIR)/build/lib -lgtest -lgtest_main -lpthread
-+LDFLAGS = $(shell uhdm-yosys-config --ldflags)
++CXX = $(shell $(YOSYS_CONFIG) --cxx)
++CXXFLAGS = $(shell $(YOSYS_CONFIG) --cxxflags) -I.. -I$(GTEST_DIR)/include
++LDLIBS = $(shell $(YOSYS_CONFIG) --ldlibs) -L$(GTEST_DIR)/build/lib -lgtest -lgtest_main -lpthread
++LDFLAGS = $(shell $(YOSYS_CONFIG) --ldflags)
 +TEST_UTILS = ../../../test-utils/test-utils.tcl
  
  define test_tpl =

--- a/syn/yosys-uhdm/yosys.patch
+++ b/syn/yosys-uhdm/yosys.patch
@@ -2,6 +2,15 @@ diff --git a/yosys/Makefile b/yosys/Makefile
 index 8275d8336..2176b149f 100644
 --- a/yosys/Makefile
 +++ b/yosys/Makefile
+@@ -140,7 +140,7 @@ bumpversion:
+ # is just a symlink to your actual ABC working directory, as 'make mrproper'
+ # will remove the 'abc' directory and you do not want to accidentally
+ # delete your work on ABC..
+-ABCREV = 4f5f73d
++ABCREV = f6fa2dd
+ ABCPULL = 1
+ ABCURL ?= https://github.com/YosysHQ/abc
+ ABCMKARGS = CC="$(CXX)" CXX="$(CXX)" ABC_USE_LIBSTDCXX=1 VERBOSE=$(Q)
 @@ -346,6 +346,20 @@ ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -DWIN32_NO_DLL -DHAVE_STRUCT_TIMESPEC
  ABCMKARGS += LIBS="-lpthread -s" ABC_USE_NO_READLINE=0 CC="x86_64-w64-mingw32-gcc" CXX="$(CXX)"
  EXE = .exe


### PR DESCRIPTION
Development of the uhdm-plugin was moved to symbiflow-yosys-plugins repository.
Now Surelog is required to build symbiflow-yosys-plugins. This PR adapts for this change.
