### PR TITLE
pnr: arachne: remove symbiflow-yosys from deps

### DIFF
--- a/pnr/arachne/meta.yaml
+++ b/pnr/arachne/meta.yaml
@@ -31,13 +31,11 @@ requirements:
     - iverilog
     - libffi
     - tk
-    - symbiflow-yosys
   run:
     - icestorm
     - iverilog
     - libffi
     - tk
-    - symbiflow-yosys
 
 test:
   commands:


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

The symbiflow-yosys package will soon be deprecated. Moreover, the pnr tool should not depend on the synthesis tool, so it should be completely removed