### PR TITLE
Fix paths in `conda-ci` and remove `scripts` submodule

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -32,8 +32,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #2
@@ -44,8 +42,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #3
@@ -56,8 +52,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #4
@@ -68,8 +62,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #5
@@ -80,8 +72,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #6
@@ -92,8 +82,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #7
@@ -104,8 +92,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #8
@@ -116,8 +102,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #9
@@ -129,8 +113,6 @@ jobs:
       PYTHON_VERSION: "3.7"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #10
@@ -142,8 +124,6 @@ jobs:
       PYTHON_VERSION: "3.8"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #11
@@ -155,8 +135,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #12
@@ -168,8 +146,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #13
@@ -180,8 +156,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #14
@@ -192,8 +166,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #15
@@ -205,8 +177,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #16
@@ -217,8 +187,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #17
@@ -229,8 +197,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #18
@@ -241,8 +207,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #19
@@ -253,8 +217,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #20
@@ -265,8 +227,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #21
@@ -280,8 +240,6 @@ jobs:
       # Skip if token isn't available (cross-repository PRs mainly)
       - run: if [ "$ANACONDA_TOKEN" = "" ]; then echo "SKIP=true" >>$GITHUB_ENV; fi
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #22
@@ -295,8 +253,6 @@ jobs:
       # Skip if token isn't available (cross-repository PRs mainly)
       - run: if [ "$ANACONDA_TOKEN" = "" ]; then echo "SKIP=true" >>$GITHUB_ENV; fi
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #23
@@ -308,8 +264,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #24
@@ -321,8 +275,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #25
@@ -333,8 +285,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #26
@@ -347,8 +297,6 @@ jobs:
       USE_PYPY: "1"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - name: 'Install pypy'
         run: |
           sudo add-apt-repository ppa:pypy/ppa -y
@@ -364,8 +312,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #28
@@ -379,8 +325,6 @@ jobs:
       SKIP: "true"  # See https://github.com/litex-hub/litex-conda-eda/issues/70
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #29
@@ -394,8 +338,6 @@ jobs:
       SKIP: "true"  # See https://github.com/litex-hub/litex-conda-eda/issues/70
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #30
@@ -408,8 +350,6 @@ jobs:
       SCRIPT: ${{ format('{0}{1}', github.workspace, '/xilinx/vivado/gen_metapackages.sh') }}
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #31
@@ -420,8 +360,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #32
@@ -432,8 +370,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #33
@@ -444,8 +380,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #34
@@ -457,8 +391,6 @@ jobs:
       SKIP: "true"  # See https://github.com/hdl/conda-eda/issues/97
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #35
@@ -470,8 +402,6 @@ jobs:
       EXTRA_BUILD_ARGS: "--no-test"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #36
@@ -483,8 +413,6 @@ jobs:
       EXTRA_BUILD_ARGS: "--no-test"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #37
@@ -496,8 +424,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #38
@@ -510,8 +436,6 @@ jobs:
       SKIP: "true"  # See https://github.com/litex-hub/litex-conda-eda/issues/71
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #39
@@ -523,8 +447,6 @@ jobs:
       SKIP: "true"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #40
@@ -536,8 +458,6 @@ jobs:
       SKIP: "true"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #41
@@ -549,8 +469,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #42
@@ -561,8 +479,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #43
@@ -573,8 +489,6 @@ jobs:
       OS_NAME: "windows"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #44
@@ -585,8 +499,6 @@ jobs:
       OS_NAME: "windows"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #45
@@ -597,8 +509,6 @@ jobs:
       OS_NAME: "windows"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #46
@@ -609,8 +519,6 @@ jobs:
       OS_NAME: "windows"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #47
@@ -621,8 +529,6 @@ jobs:
       OS_NAME: "windows"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #48
@@ -635,8 +541,6 @@ jobs:
       SKIP: "true"  # See: https://github.com/hdl/conda-eda/issues/120
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #49
@@ -648,8 +552,6 @@ jobs:
       SKIP: "true"  # See: https://github.com/hdl/conda-eda/issues/120
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #50
@@ -661,8 +563,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #51
@@ -674,8 +574,6 @@ jobs:
       SKIP: "true"  # See https://github.com/litex-hub/litex-conda-eda/issues/73
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #52
@@ -686,8 +584,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #53
@@ -699,8 +595,6 @@ jobs:
       USE_SYSTEM_GCC_VERSION: "9"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #54
@@ -711,8 +605,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #55
@@ -723,8 +615,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #56
@@ -737,8 +627,6 @@ jobs:
       PYTHON_VERSION: "3.7"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #57
@@ -751,8 +639,6 @@ jobs:
       PYTHON_VERSION: "3.8"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #58
@@ -766,8 +652,6 @@ jobs:
       PYTHON_VERSION: "3.7"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #59
@@ -781,8 +665,6 @@ jobs:
       PYTHON_VERSION: "3.8"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #60
@@ -795,8 +677,6 @@ jobs:
       PYTHON_VERSION: "3.7"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #61
@@ -809,8 +689,6 @@ jobs:
       PYTHON_VERSION: "3.8"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #62
@@ -821,8 +699,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #63
@@ -834,8 +710,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #64
@@ -848,8 +722,6 @@ jobs:
       PYTHON_VERSION: "3.7"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #65
@@ -862,8 +734,6 @@ jobs:
       PYTHON_VERSION: "3.8"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #66
@@ -874,8 +744,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #67
@@ -886,8 +754,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
 
@@ -895,14 +761,20 @@ jobs:
     runs-on: "ubuntu-20.04"
     env:
       OS_NAME: "linux"
+      CI_SCRIPTS_REL_PATH: "conda-ci"
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
-          submodules: 'true'
+          repository: hdl/conda-ci
+          ref: master
+          path: ${{ env.CI_SCRIPTS_REL_PATH }}
       - uses: actions/setup-python@v1
       - uses: BSFishy/pip-action@v1
         with:
           packages: urllib3
       - run: |
-          bash .github/scripts/install.sh
-          python .github/scripts/wait-for-statuses.py
+          # Required internally by the scripts to locate other scripts.
+          export CI_SCRIPTS_PATH="$GITHUB_WORKSPACE/$CI_SCRIPTS_REL_PATH"
+          bash $CI_SCRIPTS_PATH/install.sh
+          python $CI_SCRIPTS_PATH/wait-for-statuses.py

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "conda-ci"]
-	path = .github/scripts
-	url = https://github.com/hdl/conda-ci.git
-	branch = master

--- a/xilinx/vivado/gen_metapackages.sh
+++ b/xilinx/vivado/gen_metapackages.sh
@@ -8,7 +8,7 @@ do
 	export XILINX_VIVADO_VERSION=$version
 
 	# Initialize Conda
-	. $GITHUB_WORKSPACE/.github/scripts/common.sh
+	. $CI_SCRIPTS_PATH/common.sh
 	eval "$('conda' 'shell.bash' 'hook' 2> /dev/null)"
 
 	# Remove previously prepared recipe directory
@@ -20,6 +20,6 @@ do
 	python -m conda_build_prepare --dir workdir --packages $ADDITIONAL_PACKAGES -- $PACKAGE
 
 	# Build metapackage
-	bash $GITHUB_WORKSPACE/.github/scripts/script.sh
-	bash $GITHUB_WORKSPACE/.github/scripts/after_success.sh
+	bash $CI_SCRIPTS_PATH/script.sh
+	bash $CI_SCRIPTS_PATH/after_success.sh
 done < "$input"


### PR DESCRIPTION
The `aj-fix-ci` branch used in the workflow has been approved to be merged in: https://github.com/hdl/conda-ci/pull/20

Some adjustments have to be made, especially to the `xilinx-vivado` and `master-package` jobs but with these changes, the `scripts` submodule (pointing to `conda-ci`) can be removed.
The only place influencing script versions will now be held in the workflow and we won't need to bump submodules with each `conda-ci` change.