### PR TITLE
misc: add open_pdks

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -18,7 +18,7 @@ on:
 env:
   ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
   ANACONDA_USER: ${{ secrets.ANACONDA_USER }}
-  NUM_OF_JOBS: 67
+  NUM_OF_JOBS: 68
 defaults:
   run:
     shell: bash
@@ -758,6 +758,15 @@ jobs:
       - uses: actions/checkout@v2
       - uses: hdl/conda-ci@master
 
+  #68
+  open_pdks-linux:
+    runs-on: "ubuntu-20.04"
+    env:
+      PACKAGE: "misc/open_pdks"
+      OS_NAME: "linux"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hdl/conda-ci@master
 
   master-package:
     runs-on: "ubuntu-20.04"

--- a/misc/open_pdks/build.sh
+++ b/misc/open_pdks/build.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# sanity check
+test -d $SRC_DIR/skywater-pdk/libraries/sky130_fd_sc_hd/latest/cells
+test -d $SRC_DIR/skywater-pdk/libraries/sky130_fd_sc_hd/latest/models
+test -d $SRC_DIR/skywater-pdk/libraries/sky130_fd_sc_hd/latest/tech
+test -d $SRC_DIR/skywater-pdk/libraries/sky130_fd_sc_hd/latest/timing
+test -d $SRC_DIR/skywater-pdk/libraries/sky130_fd_sc_hvl/latest/cells
+test -d $SRC_DIR/skywater-pdk/libraries/sky130_fd_sc_hvl/latest/models
+test -d $SRC_DIR/skywater-pdk/libraries/sky130_fd_sc_hvl/latest/tech
+test -d $SRC_DIR/skywater-pdk/libraries/sky130_fd_sc_hvl/latest/timing
+test -d $SRC_DIR/skywater-pdk/libraries/sky130_fd_io/latest/cells
+test -d $SRC_DIR/skywater-pdk/libraries/sky130_fd_pr/latest/cells
+test -d $SRC_DIR/skywater-pdk/libraries/sky130_fd_pr/latest/models
+test -d $SRC_DIR/skywater-pdk/libraries/sky130_fd_pr/latest/tech
+
+# make timing
+pushd $SRC_DIR/skywater-pdk/scripts/python-skywater-pdk/
+
+for LIB in $SRC_DIR/skywater-pdk/libraries/sky130_*_sc_*/latest; do
+  if [ -d "$LIB/cells" ]; then
+    $PYTHON -m skywater_pdk.liberty $LIB
+    $PYTHON -m skywater_pdk.liberty $LIB all
+    $PYTHON -m skywater_pdk.liberty $LIB all --ccsnoise
+  fi
+done
+popd
+
+# timing check
+find $SRC_DIR/skywater-pdk/libraries/sky130_fd_sc_hd/latest -path '*/timing/*.lib' -type f -print | grep timing
+find $SRC_DIR/skywater-pdk/libraries/sky130_fd_sc_hvl/latest -path '*/timing/*.lib' -type f -print | grep timing
+
+# extract variant name from package name
+VARIANT=${PKG_NAME#open_pdks.sky130}
+VARIANT=${VARIANT^^}
+
+# --enable-sky130-pdk: point to current checkout
+# --disable-alpha-sky130: disable font library
+# --disable-xschem-sky130: disable xschem integration
+# --with-sky130-variants: use specified variant 
+./configure --prefix=$PREFIX \
+  --enable-sky130-pdk=$SRC_DIR/skywater-pdk/ \
+  --disable-alpha-sky130 \
+  --disable-xschem-sky130 \
+  --with-sky130-variants=$VARIANT
+make V=1
+make V=1 install

--- a/misc/open_pdks/condarc
+++ b/misc/open_pdks/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/misc/open_pdks/meta.yaml
+++ b/misc/open_pdks/meta.yaml
@@ -1,0 +1,56 @@
+# Use `conda-build-prepare` before building for a better version string.
+{% set version = '%s_%04i_%s'| format(GIT_DESCRIBE_TAG | default('0.X'), GIT_DESCRIBE_NUMBER | default(0) | int, GIT_DESCRIBE_HASH | default('gUNKNOWN')) %}
+
+package:
+  name: open_pdks.sky130a
+  version: {{ version }}
+
+source:
+  - git_url: https://github.com/RTimothyEdwards/open_pdks.git
+    git_rev: master
+  - url: https://github.com/google/skywater-pdk/archive/refs/heads/main.zip
+    folder: skywater-pdk
+  - url: https://github.com/google/skywater-pdk-libs-sky130_fd_sc_hd/archive/refs/heads/branch-0.0.2.zip
+    folder: skywater-pdk/libraries/sky130_fd_sc_hd/latest
+  - url: https://github.com/google/skywater-pdk-libs-sky130_fd_sc_hvl/archive/refs/heads/branch-0.0.3.zip
+    folder: skywater-pdk/libraries/sky130_fd_sc_hvl/latest
+  - url: https://github.com/google/skywater-pdk-libs-sky130_fd_io/archive/refs/heads/branch-0.2.1.zip
+    folder: skywater-pdk/libraries/sky130_fd_io/latest
+  - url: https://github.com/google/skywater-pdk-libs-sky130_fd_pr/archive/refs/heads/branch-0.20.1.zip
+    folder: skywater-pdk/libraries/sky130_fd_pr/latest
+
+build:
+  noarch: generic
+  # number: 202202031935
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20220203_1935
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    
+requirements:
+  build:
+    - autoconf
+    - automake
+    - make
+  host:
+    - dataclasses-json
+    - python
+    - pip
+    - magic
+
+test:
+  commands:
+    - test -d $PREFIX/share/pdk/sky130A/libs.ref/sky130_fd_sc_hd
+    - test -d $PREFIX/share/pdk/sky130A/libs.ref/sky130_fd_sc_hvl
+    - test -d $PREFIX/share/pdk/sky130A/libs.ref/sky130_fd_io
+    - test -d $PREFIX/share/pdk/sky130A/libs.ref/sky130_fd_pr
+  
+about:
+  home: http://opencircuitdesign.com/open_pdks/
+  license: Apache-2.0
+  summary: 'PDK installer for open-source EDA tools and toolchains. Distributed with a setup for the Google/SkyWater 130nm process.'
+
+extra:
+  recipe-maintainers:
+    - proppy


### PR DESCRIPTION
Fixes #160
Depends on #161 

- package  as `open_pdks.sky130a`
- mimic `make timing` in build script to leverage conda environment for build dependencies

@mithro and @PiotrZierhoffer for review
@olofk @RTimothyEdwards  should we expose more combination of libs as different subpackages?
