### PR TITLE
pnr: add openroad

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -18,7 +18,7 @@ on:
 env:
   ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
   ANACONDA_USER: ${{ secrets.ANACONDA_USER }}
-  NUM_OF_JOBS: 68
+  NUM_OF_JOBS: 69
 defaults:
   run:
     shell: bash
@@ -763,6 +763,16 @@ jobs:
     runs-on: "ubuntu-20.04"
     env:
       PACKAGE: "misc/open_pdks"
+      OS_NAME: "linux"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hdl/conda-ci@master
+
+  #69
+  openroad-linux:
+    runs-on: "ubuntu-20.04"
+    env:
+      PACKAGE: "pnr/openroad"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2

--- a/pnr/openroad/build.sh
+++ b/pnr/openroad/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+mkdir build
+cd build
+cmake -DCMAKE_FIND_ROOT_PATH="$BUILD_PREFIX;$PREFIX" -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=ONLY -DUSE_SYSTEM_BOOST=ON -DINSTALL_LIBOPENSTA=OFF -DBUILD_GUI=OFF -DCMAKE_INSTALL_PREFIX=$PREFIX  ..
+make -j$CPU_COUNT
+make -j$CPU_COUNT install

--- a/pnr/openroad/condarc
+++ b/pnr/openroad/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/pnr/openroad/gui-find-qt-only-if-enabled.patch
+++ b/pnr/openroad/gui-find-qt-only-if-enabled.patch
@@ -1,0 +1,23 @@
+diff --git a/src/gui/CMakeLists.txt b/src/gui/CMakeLists.txt
+index 204e14956..9e8a1bac3 100755
+--- a/src/gui/CMakeLists.txt
++++ b/src/gui/CMakeLists.txt
+@@ -1,15 +1,13 @@
+ # Allow users to not build without the gui even if Qt is found
+ option(BUILD_GUI "Build the GUI" ON)
+ 
+-# If Qt is not installed there will not be cmake
+-# support for the package so this needs to be "quiet".
+-find_package(Qt5 QUIET COMPONENTS Core Widgets)
+-
+ include("openroad")
+ set(CMAKE_INCLUDE_CURRENT_DIR ON)
+ 
+-if (Qt5_FOUND AND BUILD_GUI)
++if (BUILD_GUI)
+   message(STATUS "GUI is enabled")
++  find_package(Qt5 QUIET COMPONENTS Core Widgets)
++
+   set(CMAKE_AUTOMOC ON)
+   set(CMAKE_AUTORCC ON)
+   set(CMAKE_AUTOUIC ON)

--- a/pnr/openroad/meta.yaml
+++ b/pnr/openroad/meta.yaml
@@ -1,0 +1,65 @@
+# Use `conda-build-prepare` before building for a better version string.
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v', '')|replace('-', '')|default('0.X'), GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH|default('gUNKNOWN')) %}
+
+package:
+  name: openroad
+  version: {{ version }}
+
+source:
+  - git_url: https://github.com/The-OpenROAD-Project/OpenROAD.git
+    git_rev: master
+    patches:
+      - odb-drt-disable-tests.patch
+      - sta-add-install-options.patch
+      - gui-find-qt-only-if-enabled.patch
+
+build:
+  # number: 202202031935
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20220203_1935
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+  ignore_run_exports_from:
+    # header-only libraries
+    - lemon
+    - fmt
+
+requirements:
+  build:
+    - make
+    - cmake >=3.19
+    - swig 4.0.1
+    - bison
+    - doxygen
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - python
+    - boost-cpp 1.76
+    - eigen 3.3
+    - lemon 1.3.1
+    - spdlog 1.8.1
+    - readline
+    - tk
+    - zlib
+    - fmt
+    - libgomp
+  run:
+    # missing run_exports
+    - {{ pin_compatible('boost-cpp', min_pin='x.x', max_pin='x.x') }}
+    - {{ pin_compatible('python', min_pin='x.x', max_pin='x.x') }}    
+    
+test:
+  commands:
+    - openroad -version
+    - sta -version
+
+about:
+  home: https://theopenroadproject.org/
+  license: BSD-3-Clause
+  summary: OpenROAD is an unified application implementing an RTL-to-GDS Flow.
+
+extra:
+  recipe-maintainers:
+    - proppy

--- a/pnr/openroad/odb-drt-disable-tests.patch
+++ b/pnr/openroad/odb-drt-disable-tests.patch
@@ -1,0 +1,60 @@
+diff --git a/src/drt/CMakeLists.txt b/src/drt/CMakeLists.txt
+index ce93a063e..2c3afc754 100644
+--- a/src/drt/CMakeLists.txt
++++ b/src/drt/CMakeLists.txt
+@@ -159,43 +159,6 @@ target_compile_options(drt
+     $<$<CXX_COMPILER_ID:Clang>:-Wall -pedantic -Wcast-qual -Wredundant-decls -Wformat-security -Wno-gnu-zero-variadic-macro-arguments>
+   )
+ 
+-############################################################
+-# Unit testing
+-############################################################
+-enable_testing()
+-
+-add_executable(trTest
+-  ${FLEXROUTE_HOME}/test/gcTest.cpp
+-  ${FLEXROUTE_HOME}/test/fixture.cpp
+-)
+-
+-target_include_directories(trTest
+-  PRIVATE
+-  ${FLEXROUTE_HOME}/src
+-  ${OPENROAD_HOME}/include
+-)
+-
+-target_link_libraries(trTest
+-  drt
+-  odb
+-)
+-
+-# Use the shared library if found.  We need to pass this info to
+-# the code to select the corresponding include.  Using the shared
+-# library speeds up compilation.
+-if (Boost_unit_test_framework_FOUND)
+-  message(STATUS "Boost unit_test_framework library found")
+-  target_link_libraries(trTest
+-    Boost::unit_test_framework
+-  )
+-  target_compile_definitions(trTest
+-    PRIVATE
+-    HAS_BOOST_UNIT_TEST_LIBRARY
+-  )
+-endif()
+-
+-add_test(NAME trTest COMMAND trTest)
+-
+ ############################################################
+ # VTune ITT API
+ ############################################################
+diff --git a/src/odb/CMakeLists.txt b/src/odb/CMakeLists.txt
+index 7e55b669c..4614df8bf 100644
+--- a/src/odb/CMakeLists.txt
++++ b/src/odb/CMakeLists.txt
+@@ -29,7 +29,6 @@ add_subdirectory(src/zutil)
+ add_subdirectory(src/zlib)
+ add_subdirectory(src/tm)
+ add_subdirectory(src/cdl)
+-add_subdirectory(test/cpp)
+ ############################################################################
+ ################################# SWIG #####################################
+ ############################################################################

--- a/pnr/openroad/sta-add-install-options.patch
+++ b/pnr/openroad/sta-add-install-options.patch
@@ -1,0 +1,26 @@
+diff --git a/src/sta/CMakeLists.txt b/src/sta/CMakeLists.txt
+index 159ee19..badd706 100644
+--- a/src/sta/CMakeLists.txt
++++ b/src/sta/CMakeLists.txt
+@@ -30,6 +30,7 @@ project(STA VERSION 2.3.1
+ 
+ option(USE_CUDD "Use CUDD BDD package")
+ option(CUDD_DIR "CUDD BDD package directory")
++option(INSTALL_LIBOPENSTA "Install OpenSTA library and headers")
+ 
+ set(CMAKE_VERBOSE_MAKEFILE ON)
+ 
+@@ -511,11 +512,13 @@ message(STATUS "STA executable: ${STA_HOME}/app/sta")
+ # executable
+ install(TARGETS sta DESTINATION bin)
+ 
++if (INSTALL_LIBOPENSTA)
+ # library
+ install(TARGETS OpenSTA DESTINATION lib)
+ 
+ # include
+ install(DIRECTORY include/sta  DESTINATION include)
++endif()
+ 
+ ################################################################
+ 


### PR DESCRIPTION
Fixes #150 

- distribute `openroad.app` `openroad.sta` and openroad.libsta` as subpackages
- distribute `openroad` meta package with `.app` and `.sta`
- patch to remove testing (failed to link against `rt`)
- user conda-eda convention (build from git/master, use `conda-build-prepare` for version string)

@PiotrZierhoffer @mithro for review

@maliberty fyi