### PR TITLE
hls: add xls

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -18,7 +18,7 @@ on:
 env:
   ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
   ANACONDA_USER: ${{ secrets.ANACONDA_USER }}
-  NUM_OF_JOBS: 69
+  NUM_OF_JOBS: 70
 defaults:
   run:
     shell: bash
@@ -774,6 +774,18 @@ jobs:
     runs-on: "ubuntu-20.04"
     env:
       PACKAGE: "pnr/openroad"
+      OS_NAME: "linux"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hdl/conda-ci@master
+
+  #70
+  xls-linux:
+    # uses older ubuntu for better compat:
+    # https://github.com/hdl/conda-eda/issues/199
+    runs-on: "ubuntu-18.04"
+    env:
+      PACKAGE: "hls/xls"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2

--- a/hls/xls/add-dist-rule.patch
+++ b/hls/xls/add-dist-rule.patch
@@ -1,0 +1,42 @@
+diff --git a/WORKSPACE b/WORKSPACE
+index 9bdffca5f..3466a8e36 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -50,3 +50,15 @@ initialize_external_repositories()
+ load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
+ 
+ grpc_extra_deps()
++
++http_archive(
++    name = "rules_pkg",
++    urls = [
++        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz",
++        "https://github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz",
++    ],
++    sha256 = "a89e203d3cf264e564fcb96b6e06dd70bc0557356eb48400ce4b5d97c2c3720d",
++)
++
++load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
++rules_pkg_dependencies()
+diff --git a/xls/BUILD b/xls/BUILD
+index f97480caf..d6bd5292b 100644
+--- a/xls/BUILD
++++ b/xls/BUILD
+@@ -83,4 +83,17 @@ package(
+     licenses = ["notice"],  # Apache 2.0
+ )
+ 
++load("@rules_pkg//:pkg.bzl", "pkg_tar")
++
++pkg_tar(
++    name = "dist",
++    extension = "tar.gz",
++    srcs = [
++        "//xls/dslx:interpreter_main",
++        "//xls/dslx:ir_converter_main",
++        "//xls/tools:opt_main",
++        "//xls/tools:codegen_main",
++    ],
++)
++
+ exports_files(["LICENSE"])

--- a/hls/xls/build.sh
+++ b/hls/xls/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -ex
+
+bazel build -c opt \
+  --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux \
+  //xls/dslx:interpreter_main \
+  //xls/dslx:ir_converter_main \
+  //xls/tools:opt_main \
+  //xls/tools:codegen_main
+
+cp bazel-bin/xls/dslx/interpreter_main \
+   bazel-bin/xls/dslx/ir_converter_main \
+   bazel-bin/xls/tools/opt_main \
+   bazel-bin/xls/tools/codegen_main $PREFIX/bin/

--- a/hls/xls/condarc
+++ b/hls/xls/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/hls/xls/meta.yaml
+++ b/hls/xls/meta.yaml
@@ -1,0 +1,54 @@
+# Use `conda-build-prepare` before building for a better version string.
+{% set version = '%s_%04i_%s'| format(GIT_DESCRIBE_TAG | default('0.0.0') , GIT_DESCRIBE_NUMBER | default(0) | int, GIT_DESCRIBE_HASH | default('gUNKNOWN')) %}
+
+package:
+  name: xls
+  version: {{ version }}
+
+source:
+  - git_url: https://github.com/google/xls.git
+    git_rev: main
+    patches:
+      - skip-python-requirements.patch
+      - use-llvm-toolchain.patch      
+
+build:
+  # number: 202202082028
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20220208_2028
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+
+requirements:
+  build:
+    - bazel
+  host:
+    - python
+    - pip
+    - protobuf
+    - pycparser 2.19
+    - Flask 1.1.2
+    - Jinja2 2.11.3
+    - werkzeug 1.0.1
+    - itsdangerous 1.1.0
+    - MarkupSafe 2.0
+    - click 7.1.2
+    - numpy >=1.19.5,<=1.20.0
+    - scipy >=1.5.4,<=1.6.0
+    
+test:
+  commands:
+    - interpreter_main --version
+    - ir_converter_main --version
+    - opt_main --version
+    - codegen_main --version
+
+about:
+  home: https://google.github.io/xls/
+  license: Apache-2.0
+  summary: Accelerated HW Synthesis
+
+extra:
+  recipe-maintainers:
+    - proppy

--- a/hls/xls/skip-python-requirements.patch
+++ b/hls/xls/skip-python-requirements.patch
@@ -1,0 +1,248 @@
+diff --git a/dependency_support/initialize_external.bzl b/dependency_support/initialize_external.bzl
+index 1acf403d..e36ab76c 100644
+--- a/dependency_support/initialize_external.bzl
++++ b/dependency_support/initialize_external.bzl
+@@ -31,11 +31,5 @@ def initialize_external_repositories():
+     rules_hdl_dependency_support()
+     rules_closure_dependencies()
+     rules_closure_toolchains()
+-    pip_install(
+-        name = "xls_pip_deps",
+-        requirements = "@com_google_xls//dependency_support:pip_requirements.txt",
+-        python_interpreter = "python3",
+-        timeout = 600000,
+-    )
+     initialize_boost()
+     initialize_llvm_bazel()
+diff --git a/dependency_support/pip_requirements.txt b/dependency_support/pip_requirements.txt
+index 51165306..e69de29b 100644
+--- a/dependency_support/pip_requirements.txt
++++ b/dependency_support/pip_requirements.txt
+@@ -1,16 +0,0 @@
+-pycparser==2.19
+-Flask==1.1.2
+-Jinja2==2.11.3
+-werkzeug==1.0.1
+-itsdangerous==1.1.0
+-click==7.1.2
+-markupsafe==1.1.1
+-termcolor==1.1.0
+-psutil==5.7.0
+-portpicker==1.3.1
+-
+-# Note: numpy and scipy version availability seems to differ between Ubuntu
+-# versions that we want to support (e.g. 18.04 vs 20.04), so we accept a
+-# range that makes successful installation on those platforms possible.
+-numpy>=1.19.5,<=1.20.0
+-scipy>=1.5.4,<=1.6.0
+diff --git a/xls/delay_model/BUILD b/xls/delay_model/BUILD
+index a2a3d0e3..77c84034 100644
+--- a/xls/delay_model/BUILD
++++ b/xls/delay_model/BUILD
+@@ -12,8 +12,6 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-load("@xls_pip_deps//:requirements.bzl", "requirement")
+-
+ # pytype binary, test, library
+ load("//xls/build_rules:py_proto_library.bzl", "xls_py_proto_library")
+ 
+@@ -154,8 +152,6 @@ py_binary(
+     deps = [
+         ":delay_model",
+         ":delay_model_py_pb2",
+-        requirement("Jinja2"),
+-        requirement("MarkupSafe"),
+         "//xls/common:runfiles",
+         "@com_google_absl_py//absl:app",
+         "@com_google_absl_py//absl/flags",
+@@ -169,8 +165,6 @@ py_library(
+     srcs_version = "PY3ONLY",
+     deps = [
+         ":delay_model_py_pb2",
+-        requirement("numpy"),
+-        requirement("scipy"),
+     ],
+ )
+ 
+diff --git a/xls/dslx/BUILD b/xls/dslx/BUILD
+index bdce6d1c..3bc01f2d 100644
+--- a/xls/dslx/BUILD
++++ b/xls/dslx/BUILD
+@@ -17,8 +17,6 @@
+ # pytype test and library
+ # cc_proto_library is used in this file
+ 
+-load("@xls_pip_deps//:requirements.bzl", "requirement")
+-
+ package(
+     default_visibility = ["//xls:xls_internal"],
+     licenses = ["notice"],  # Apache 2.0
+diff --git a/xls/dslx/interpreter/BUILD b/xls/dslx/interpreter/BUILD
+index 2c6e1fff..e65c386a 100644
+--- a/xls/dslx/interpreter/BUILD
++++ b/xls/dslx/interpreter/BUILD
+@@ -16,8 +16,6 @@
+ 
+ # pytype tests are present in this file
+ 
+-load("@xls_pip_deps//:requirements.bzl", "requirement")
+-
+ package(
+     default_visibility = ["//xls:xls_internal"],
+     licenses = ["notice"],  # Apache 2.0
+diff --git a/xls/fuzzer/BUILD b/xls/fuzzer/BUILD
+index 13e8e3aa..06e2a49d 100644
+--- a/xls/fuzzer/BUILD
++++ b/xls/fuzzer/BUILD
+@@ -12,8 +12,6 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-load("@xls_pip_deps//:requirements.bzl", "requirement")
+-
+ # pytype binary, test, library
+ load("//xls/build_rules:py_proto_library.bzl", "xls_py_proto_library")
+ load("//xls/fuzzer:build_defs.bzl", "generate_crasher_regression_tests")
+@@ -44,7 +42,6 @@ py_library(
+     deps = [
+         ":sample_runner",
+         ":sample_summary_py_pb2",
+-        requirement("termcolor"),
+         "//xls/common:runfiles",
+         "//xls/fuzzer/python:cpp_ast_generator",
+         "//xls/fuzzer/python:cpp_sample",
+@@ -216,7 +213,6 @@ py_library(
+     deps = [
+         ":run_fuzz",
+         ":sample_runner",
+-        requirement("termcolor"),
+         "//xls/common:gfile",
+         "//xls/common:multiprocess",
+         "//xls/fuzzer/python:cpp_ast_generator",
+@@ -250,7 +246,6 @@ py_binary(
+     deps = [
+         ":cli_helpers",
+         ":run_fuzz_multiprocess_lib",
+-        requirement("psutil"),
+         "//xls/common:gfile",
+         "//xls/common:multiprocess",
+         "//xls/fuzzer/python:cpp_ast_generator",
+diff --git a/xls/ir/BUILD b/xls/ir/BUILD
+index 1302c03f..9382ef27 100644
+--- a/xls/ir/BUILD
++++ b/xls/ir/BUILD
+@@ -15,7 +15,6 @@
+ # Compiler data structures for converting high level algorithms into Hardware
+ # Description Language.
+ 
+-load("@xls_pip_deps//:requirements.bzl", "requirement")
+ load("@bazel_skylib//rules:build_test.bzl", "build_test")
+ 
+ # cc_proto_library is used in this file
+@@ -722,8 +721,6 @@ py_binary(
+     ],
+     python_version = "PY3",
+     deps = [
+-        requirement("Jinja2"),
+-        requirement("MarkupSafe"),
+         "//xls/common:runfiles",
+         "@com_google_absl_py//absl:app",
+     ],
+diff --git a/xls/solvers/python/BUILD b/xls/solvers/python/BUILD
+index 93e77f45..0a09e925 100644
+--- a/xls/solvers/python/BUILD
++++ b/xls/solvers/python/BUILD
+@@ -12,8 +12,6 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-load("@xls_pip_deps//:requirements.bzl", "requirement")
+-
+ # pytype binary, test, library
+ load("//xls/build_rules:py_proto_library.bzl", "xls_py_proto_library")
+ load("//dependency_support/pybind11:pybind11.bzl", "xls_pybind_extension")
+@@ -95,7 +93,6 @@ py_test(
+     deps = [
+         ":lec_characterizer",
+         ":lec_characterizer_py_pb2",
+-        requirement("portpicker"),
+         "//xls/common:gfile",
+         "//xls/common:runfiles",
+         "//xls/ir:op_py_pb2",
+diff --git a/xls/synthesis/BUILD b/xls/synthesis/BUILD
+index 555410c0..e84ad594 100644
+--- a/xls/synthesis/BUILD
++++ b/xls/synthesis/BUILD
+@@ -12,7 +12,6 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-load("@xls_pip_deps//:requirements.bzl", "requirement")
+ load("@com_github_grpc_grpc//bazel:python_rules.bzl", "py_grpc_library")
+ load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+ 
+@@ -147,7 +146,6 @@ py_test(
+     srcs_version = "PY3",
+     deps = [
+         ":synthesis_py_pb2",
+-        requirement("portpicker"),
+         "//xls/common:runfiles",
+         "@com_google_absl_py//absl/testing:absltest",
+         "@com_google_protobuf//:protobuf_python",
+@@ -208,7 +206,6 @@ py_test(
+     deps = [
+         ":client_credentials",
+         ":synthesis_utils",
+-        requirement("portpicker"),
+         "//xls/common:runfiles",
+         "@com_google_absl_py//absl/testing:absltest",
+     ],
+diff --git a/xls/synthesis/yosys/BUILD b/xls/synthesis/yosys/BUILD
+index eff0fe05..b0d41359 100644
+--- a/xls/synthesis/yosys/BUILD
++++ b/xls/synthesis/yosys/BUILD
+@@ -14,8 +14,6 @@
+ 
+ # pytype tests are present in this file
+ 
+-load("@xls_pip_deps//:requirements.bzl", "requirement")
+-
+ package(
+     default_visibility = ["//xls:xls_internal"],
+     licenses = ["notice"],  # Apache 2.0
+@@ -94,7 +92,6 @@ py_test(
+     python_version = "PY3",
+     srcs_version = "PY3",
+     deps = [
+-        requirement("portpicker"),
+         "//xls/common:runfiles",
+         "//xls/synthesis:synthesis_py_pb2",
+         "@com_google_absl_py//absl/testing:absltest",
+diff --git a/xls/visualization/ir_viz/BUILD b/xls/visualization/ir_viz/BUILD
+index f656f488..c8280c06 100644
+--- a/xls/visualization/ir_viz/BUILD
++++ b/xls/visualization/ir_viz/BUILD
+@@ -12,8 +12,6 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-load("@xls_pip_deps//:requirements.bzl", "requirement")
+-
+ # pytype binary and test
+ load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_binary", "closure_js_library")
+ load("//xls/examples:list_filegroup_files.bzl", "list_filegroup_files")
+@@ -56,12 +54,6 @@ py_binary(
+     python_version = "PY3",
+     srcs_version = "PY3",
+     deps = [
+-        requirement("Flask"),
+-        requirement("Jinja2"),
+-        requirement("Werkzeug"),
+-        requirement("click"),
+-        requirement("itsdangerous"),
+-        requirement("MarkupSafe"),
+         "//xls/common:runfiles",
+         "//xls/common/python:init_xls",
+         "//xls/visualization/ir_viz/python:ir_to_json",

--- a/hls/xls/use-llvm-toolchain.patch
+++ b/hls/xls/use-llvm-toolchain.patch
@@ -1,0 +1,39 @@
+diff --git a/.bazelrc b/.bazelrc
+index 2d43fa52..b0b0f9cd 100644
+--- a/.bazelrc
++++ b/.bazelrc
+@@ -5,7 +5,4 @@ build --copt "-Wno-sign-compare"
+ build --copt "-Wno-comment"
+ build --host_copt "-Wno-sign-compare"
+ build --host_copt "-Wno-comment"
+-
+-# TODO(leary): 2020-09-09 Make it possible to enable this option.
+-# Currently m4 doesn't seem to work as a dependency.
+-# build --crosstool_top=@llvm_toolchain_llvm//:toolchain
++build --incompatible_enable_cc_toolchain_resolution
+diff --git a/WORKSPACE b/WORKSPACE
+index b31cd958..05751201 100644
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -8,10 +8,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+ 
+ http_archive(
+     name = "com_grail_bazel_toolchain",
+-    sha256 = "dd03374af7885d255eb735b9065a32463a1154d9de6eb47261a49c8acc1cd497",
++    sha256 = "da607faed78c4cb5a5637ef74a36fdd2286f85ca5192222c4664efec2d529bb8",
+     strip_prefix = "bazel-toolchain-0.6.3",
+     urls = [
+-        "https://github.com/grailbio/bazel-toolchain/archive/0.6.3.zip",
++        "https://github.com/grailbio/bazel-toolchain/archive/0.6.3.tar.gz",
+     ],
+ )
+ 
+@@ -23,7 +23,7 @@ load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
+ 
+ llvm_toolchain(
+     name = "llvm_toolchain",
+-    llvm_version = "10.0.0",
++    llvm_version = "13.0.0",
+ )
+ 
+ load("@llvm_toolchain//:toolchains.bzl", "llvm_register_toolchains")


### PR DESCRIPTION
Fixes #169

- package the following binaries:
  - `interpreter_main`
  - `ir_converter_main`
  - `opt_main`
  - `codegen_main`
- drop python bazel deps in favor of conda