### PR TITLE
misc/netgen: switch source to upstream

### DIFF
--- a/misc/netgen/meta.yaml
+++ b/misc/netgen/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-   git_url: https://github.com/mithro/netgen
-   git_rev: master
+   git_url: https://github.com/RTimothyEdwards/netgen
+   git_rev: netgen-1.5
 
 build:
   # number: 201803050325


### PR DESCRIPTION
/cc @mithro @RTimothyEdwards fyi

Looks like upstream has all of the fork's patch now:
https://github.com/RTimothyEdwards/netgen/commit/7e42483986631ec36a0e798f6ad1ef0145837ff0
https://github.com/RTimothyEdwards/netgen/commit/97b0d08e4fedd96fc4c2fd2c851fa1e7e0e907dd