### PR TITLE
sim/icarus: Follow the `master` branch again

### DIFF
--- a/sim/icarus/meta.yaml
+++ b/sim/icarus/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   git_url: https://github.com/steveicarus/iverilog.git
-  git_rev: 540555fca318f142fbddaac7c93b9dc66c1febdb
+  git_rev: master
   patches:
     - fix-vvp-path.patch
     - vvp-config.patch


### PR DESCRIPTION
It's been fixed to the revision which last worked at the time but from my local test it seems the problem is gone with the current `master` branch.