### PR TITLE
misc/open_pdks: add magic as optional deps

### DIFF
--- a/misc/open_pdks/meta.yaml
+++ b/misc/open_pdks/meta.yaml
@@ -38,6 +38,8 @@ requirements:
     - python
     - pip
     - magic
+  run_constrained:
+    - {{ pin_compatible('magic', min_pin='x.x.x', max_pin='x.x.x') }}
 
 test:
   commands:


### PR DESCRIPTION
This should ensure that if installed in the same envirnment, magic has
the same version as the one used to build open_pdks.