### PR TITLE
sim/icarus: use multiline block syntax for the summary string

### DIFF
--- a/sim/icarus/build.sh
+++ b/sim/icarus/build.sh
@@ -10,6 +10,3 @@ sh ./autoconf.sh
 
 make -j$CPU_COUNT
 make install
-
-$PREFIX/bin/iverilog -V
-$PREFIX/bin/iverilog -h || true

--- a/sim/icarus/meta.yaml
+++ b/sim/icarus/meta.yaml
@@ -57,4 +57,9 @@ about:
   home: http://iverilog.icarus.com/
   license: GPLv2
   license_file: COPYING
-  summary: 'Icarus Verilog (iverilog) is a Verilog simulation and synthesis tool. It operates as a compiler, compiling source code written in Verilog (IEEE-1364) into some target format. For batch simulation, the compiler can generate an intermediate form called vvp assembly. This intermediate form is executed by the ``vvp'' command. For synthesis, the compiler generates netlists in the desired format.'
+  summary: |
+    Icarus Verilog (iverilog) is a Verilog simulation and synthesis tool.
+    It operates as a compiler, compiling source code written in Verilog (IEEE-1364) into some target format.
+    For batch simulation, the compiler can generate an intermediate form called vvp assembly.
+    This intermediate form is executed by the ``vvp'' command.
+    For synthesis, the compiler generates netlists in the desired format.'


### PR DESCRIPTION
This is for testing that YAML multiline block syntax can be used to avoid "too long" summary lines. Since git makes version control per line, it is not desirable to have full paragraphs written without newlines.

BTW, some tests which are duplicated in the build script and the test script are removed from the former.