### PR TITLE
Build Yosys with clang on Linux

### DIFF
--- a/syn/yosys/meta.yaml
+++ b/syn/yosys/meta.yaml
@@ -44,8 +44,7 @@ requirements:
     - m2-bison 3.0.4            [win]
     - m2-flex  2.6.0            [win]
     - make                      [not win]
-    - {{ compiler('c') }}       [not osx]
-    - {{ compiler('cxx') }}     [not osx]
+    - clang                     [not osx]
     - {{ compiler('c') }} 4.0   [osx]
     - {{ compiler('cxx') }} 4.0 [osx]
   host:


### PR DESCRIPTION
This is just a test of the clang behavior on Windows, related to https://github.com/google/CFU-Playground/issues/311