### PR TITLE
yosys-uhdm: Remove yosys-patches

### DIFF
--- a/syn/yosys-uhdm/build.sh
+++ b/syn/yosys-uhdm/build.sh
@@ -18,7 +18,6 @@ cd Surelog && \
 #Create aliases for gcc/gxx as `abc` uses them directly in Makefile
 alias gcc=x86_64-conda_cos6-linux-gnu-gcc
 alias gxx=x86_64-conda_cos6-linux-gnu-gcc
-cd yosys && git apply ../yosys-patches/* && cd ..
 make -C yosys ENABLE_READLINE=0 CONFIG=conda-linux PROGRAM_PREFIX=uhdm- install -j$(nproc)
 
 make -C $PWD/yosys-symbiflow-plugins/ UHDM_INSTALL_DIR=$PREFIX install -j$(nproc)


### PR DESCRIPTION
``yosys-uhdm`` package is still used by ``fpga-tool-perf``. I'm working on removing it and start using ``symbiflow-yosys-plugins`` directly: https://github.com/chipsalliance/fpga-tool-perf/pull/413. After that, ``yosys-uhdm`` can be removed completly.

Until then, lets fix failing CI.
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>