### PR TITLE
Revert "misc/open_pdks: Constrain magic version"

### DIFF
--- a/misc/open_pdks/meta.yaml
+++ b/misc/open_pdks/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - typing_inspect
     - marshmallow
     - marshmallow-enum    
-    - magic <=8.3.289
+    - magic
   run_constrained:
     - {{ pin_compatible('magic', min_pin='x.x.x', max_pin='x.x.x') }}
 


### PR DESCRIPTION
This reverts commit 3549634c1895f6666906c361018517a20dc6bca5 as
https://github.com/RTimothyEdwards/magic/issues/162 is fixed upstream.