### PR TITLE
sim/verilator: linux: Require compiler package v8 or newer

### DIFF
--- a/sim/verilator/meta.yaml
+++ b/sim/verilator/meta.yaml
@@ -20,10 +20,10 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}       [not osx]
-    - {{ compiler('cxx') }}     [not osx]
-    - {{ compiler('c') }} 4.0   [osx]
-    - {{ compiler('cxx') }} 4.0 [osx]
+    # Older Linux compiler packages doesn't contain the '...-conda-...'-prefixed
+    #   executables which are common since v8. They're required for verilation.
+    - {{ compiler('cxx') }}
+    - gxx_linux-64 >=8      [linux]
     - autoconf
     - make
   host:
@@ -32,6 +32,7 @@ requirements:
     - zlib
   run:
     - {{ compiler('cxx') }}
+    - gxx_linux-64 >=8      [linux]
     - bison
     - flex
     - ncurses

--- a/sim/verilator/meta.yaml
+++ b/sim/verilator/meta.yaml
@@ -38,8 +38,6 @@ requirements:
 
 test:
   requires:
-    - gxx_linux-64   [linux]
-    - clangxx_osx-64 [osx]
     - make
   files:
     - test/counter.v


### PR DESCRIPTION
These changes should fix the Verilator's "Could not find compiler" issue: https://github.com/google/CFU-Playground/issues/568
For no good reason Conda installs a very old compiler package with Verilator even though there are no conflicts with the latest one: https://github.com/google/CFU-Playground/issues/568#issuecomment-1178890026

The old compiler packages (prior to v8) used a different prefix for the executables hence the problem.
Let's prevent Conda from installing Verilator with such compiler packages.