### PR TITLE
misc/tree-sitter-verilog: Use `py-tree-sitter` directly

### DIFF
--- a/misc/tree-sitter-verilog/build.sh
+++ b/misc/tree-sitter-verilog/build.sh
@@ -7,6 +7,9 @@ npm install tree-sitter-cli
 
 ./node_modules/tree-sitter-cli/tree-sitter generate
 
-$PYTHON -m pip install --isolated tree_sitter
-$PYTHON -c "from tree_sitter import Language; Language.build_library(\"$PREFIX/lib/tree-sitter-verilog.so\", [\".\"])"
-$PYTHON -m pip uninstall -y tree_sitter
+# Build the 'tree_sitter/binding' extension.
+cd py-tree-sitter
+python3 setup.py build --build-lib .
+
+python3 -c 'from tree_sitter import Language; Language.build_library("tree-sitter-verilog.so", [".."])'
+mv tree-sitter-verilog.so $PREFIX/lib/

--- a/misc/tree-sitter-verilog/meta.yaml
+++ b/misc/tree-sitter-verilog/meta.yaml
@@ -6,7 +6,9 @@ package:
   version: {{ version }}
 
 source:
-  git_url: https://github.com/tree-sitter/tree-sitter-verilog.git
+  - git_url: https://github.com/tree-sitter/tree-sitter-verilog.git
+  - git_url: https://github.com/tree-sitter/py-tree-sitter
+    folder: py-tree-sitter
 
 build:
   # number: 201803050325
@@ -20,10 +22,8 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-  host:
     - nodejs
     - python
-    - pip
 
 about:
   home: https://github.com/tree-sitter/tree-sitter-verilog


### PR DESCRIPTION
For as long as I can check in the CI logs there have been troubles with
installing the latest `tree_sitter` package from PyPI (v0.20 currently):
```
No matching distribution found for setuptools>=43.0.0
```

The job still worked because Pip was then checking whether older
packages work and installed the old `tree_sitter` v0.2.1 package.

The latest Pip v22.1.2 exits with failure instead which made the job
fail for a week or so.

By using `py-tree-sitter` directly always the latest version will be
used and the PyPI dependency is removed completely.