### PR TITLE
update conda before installing packages

### DIFF
--- a/ci/conda-get.sh
+++ b/ci/conda-get.sh
@@ -32,6 +32,6 @@ conda info
 conda list
 
 echo "python==3.7.*" > $CONDA_PATH/conda-meta/pinned
+conda update -y conda
 conda install -y anaconda-client
 conda install -y python
-conda update -y conda


### PR DESCRIPTION
Installing python without updating conda beforehand caused an error `OSError: Could not find a suitable TLS CA certificate bundle, invalid path: /tmp/really-long-path/conda/lib/python3.9/site-packages/certifi/cacert.pem` in github actions. Updating conda before the installation fixed this issue.