### PR TITLE
nextpnr/prjtrellis: Fix CMake find strategy for Python

### DIFF
--- a/bit/prjtrellis/build.sh
+++ b/bit/prjtrellis/build.sh
@@ -3,8 +3,18 @@
 set -e
 set -x
 
-cd libtrellis
+# Use 'Python3_FIND_STRATEGY=LOCATION' in projects with 'cmake_minimum_required'
+# <3.15 too. More info: https://cmake.org/cmake/help/v3.22/policy/CMP0094.html
+#
+# The 'CMAKE_ARGS' variable contains arguments recommended for building by Conda.
+CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_POLICY_DEFAULT_CMP0094=NEW"
+
+mkdir -p libtrellis/build
+cd libtrellis/build
+
 cmake \
+	${CMAKE_ARGS} \
+	\
 	-DCMAKE_INSTALL_PREFIX=/ 			\
 	-DCMAKE_INSTALL_BINDIR='/bin'			\
 	-DCMAKE_INSTALL_DATADIR='/share'		\
@@ -16,10 +26,6 @@ cmake \
 	-DCMAKE_INSTALL_LIBEXECDIR='/libexec'		\
 	-DCMAKE_INSTALL_LOCALEDIR='/share/locale'	\
 	\
-	-DPYTHON_EXECUTABLE=$(which python) \
-	-DPYTHON_INCLUDE_DIR=$(python -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())")  \
-	-DPYTHON_LIBRARY=$(python -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR'))") \
-	\
 	-DBOOST_ROOT="${BUILD_PREFIX}" \
 	-DBoost_NO_SYSTEM_PATHS:BOOL=ON \
 	-DBOOST_INCLUDEDIR="${BUILD_PREFIX}/include" \
@@ -28,7 +34,7 @@ cmake \
 	-DBUILD_SHARED=ON \
 	-DSTATIC_BUILD=OFF \
 	-DBoost_USE_STATIC_LIBS=ON \
-	.
+	..
 
 make -j$CPU_COUNT
 make DESTDIR=${PREFIX} install

--- a/pnr/nextpnr/ecp5/build.sh
+++ b/pnr/nextpnr/ecp5/build.sh
@@ -3,14 +3,19 @@
 set -e
 set -x
 
-cmake \
-	-DARCH=ecp5				\
-	-DBUILD_GUI=OFF				\
-	-DTRELLIS_INSTALL_PREFIX=${PREFIX}	\
-	-DTRELLIS_ROOT=${PREFIX}/share/trellis	\
-	-DCMAKE_INSTALL_PREFIX=/		\
-	-DENABLE_READLINE=No			\
-	.
+RECIPE_CMAKE_ARGS=(
+  # The variable set by Conda.
+  $CMAKE_ARGS
 
+  -DARCH=ecp5
+  -DBUILD_GUI=OFF
+  -DTRELLIS_INSTALL_PREFIX=$PREFIX
+  -DCMAKE_INSTALL_PREFIX=/
+  )
+
+mkdir -p build
+cd build
+
+cmake ${RECIPE_CMAKE_ARGS[@]} ..
 make -k -j${CPU_COUNT} || true
 make DESTDIR=${PREFIX} install

--- a/pnr/nextpnr/ecp5/build.sh
+++ b/pnr/nextpnr/ecp5/build.sh
@@ -7,6 +7,10 @@ RECIPE_CMAKE_ARGS=(
   # The variable set by Conda.
   $CMAKE_ARGS
 
+  # Use 'Python3_FIND_STRATEGY=LOCATION' in projects with 'cmake_minimum_required' <3.15 too.
+  # More info: https://cmake.org/cmake/help/v3.22/policy/CMP0094.html
+  -DCMAKE_POLICY_DEFAULT_CMP0094=NEW
+
   -DARCH=ecp5
   -DBUILD_GUI=OFF
   -DTRELLIS_INSTALL_PREFIX=$PREFIX

--- a/pnr/nextpnr/fpga_interchange/build.sh
+++ b/pnr/nextpnr/fpga_interchange/build.sh
@@ -3,14 +3,19 @@
 set -e
 set -x
 
-export PYTHON_EXECUTABLE=`which python3`
+RECIPE_CMAKE_ARGS=(
+  # The variable set by Conda.
+  $CMAKE_ARGS
+
+  -DARCH=fpga_interchange
+  )
 
 cd nextpnr
 mkdir -p build
-pushd build
-cmake -DARCH=fpga_interchange -DCMAKE_INSTALL_PREFIX=${PREFIX} -DPYTHON_EXECUTABLE=$PYTHON_EXECUTABLE ..
+cd build
 
+cmake ${RECIPE_CMAKE_ARGS[@]} ..
 make -j${CPU_COUNT}
-
 make install
+
 cp bba/bbasm ${PREFIX}/bin

--- a/pnr/nextpnr/fpga_interchange/build.sh
+++ b/pnr/nextpnr/fpga_interchange/build.sh
@@ -7,6 +7,10 @@ RECIPE_CMAKE_ARGS=(
   # The variable set by Conda.
   $CMAKE_ARGS
 
+  # Use 'Python3_FIND_STRATEGY=LOCATION' in projects with 'cmake_minimum_required' <3.15 too.
+  # More info: https://cmake.org/cmake/help/v3.22/policy/CMP0094.html
+  -DCMAKE_POLICY_DEFAULT_CMP0094=NEW
+
   -DARCH=fpga_interchange
   )
 

--- a/pnr/nextpnr/generic/build.sh
+++ b/pnr/nextpnr/generic/build.sh
@@ -3,8 +3,18 @@
 set -e
 set -x
 
-cmake -DARCH=generic -DBUILD_GUI=OFF -DCMAKE_INSTALL_PREFIX=/ -DENABLE_READLINE=No .
-make -k -j${CPU_COUNT} || true
-make
+RECIPE_CMAKE_ARGS=(
+  # The variable set by Conda.
+  $CMAKE_ARGS
 
+  -DARCH=generic
+  -DBUILD_GUI=OFF
+  -DCMAKE_INSTALL_PREFIX=/
+  )
+
+mkdir -p build
+cd build
+
+cmake ${RECIPE_CMAKE_ARGS[@]} ..
+make -k -j${CPU_COUNT} || true
 make DESTDIR=${PREFIX} install

--- a/pnr/nextpnr/generic/build.sh
+++ b/pnr/nextpnr/generic/build.sh
@@ -7,6 +7,10 @@ RECIPE_CMAKE_ARGS=(
   # The variable set by Conda.
   $CMAKE_ARGS
 
+  # Use 'Python3_FIND_STRATEGY=LOCATION' in projects with 'cmake_minimum_required' <3.15 too.
+  # More info: https://cmake.org/cmake/help/v3.22/policy/CMP0094.html
+  -DCMAKE_POLICY_DEFAULT_CMP0094=NEW
+
   -DARCH=generic
   -DBUILD_GUI=OFF
   -DCMAKE_INSTALL_PREFIX=/

--- a/pnr/nextpnr/ice40/build.sh
+++ b/pnr/nextpnr/ice40/build.sh
@@ -3,8 +3,19 @@
 set -e
 set -x
 
-cmake -DARCH=ice40 -DBUILD_GUI=OFF -DICEBOX_ROOT=${PREFIX}/share/icebox -DCMAKE_INSTALL_PREFIX=/ -DENABLE_READLINE=No .
-make -k -j${CPU_COUNT} || true
-make
+RECIPE_CMAKE_ARGS=(
+  # The variable set by Conda.
+  $CMAKE_ARGS
 
+  -DARCH=ice40
+  -DBUILD_GUI=OFF
+  -DICESTORM_INSTALL_PREFIX=$PREFIX
+  -DCMAKE_INSTALL_PREFIX=/
+  )
+
+mkdir -p build
+cd build
+
+cmake ${RECIPE_CMAKE_ARGS[@]} ..
+make -k -j${CPU_COUNT} || true
 make DESTDIR=${PREFIX} install

--- a/pnr/nextpnr/ice40/build.sh
+++ b/pnr/nextpnr/ice40/build.sh
@@ -7,6 +7,10 @@ RECIPE_CMAKE_ARGS=(
   # The variable set by Conda.
   $CMAKE_ARGS
 
+  # Use 'Python3_FIND_STRATEGY=LOCATION' in projects with 'cmake_minimum_required' <3.15 too.
+  # More info: https://cmake.org/cmake/help/v3.22/policy/CMP0094.html
+  -DCMAKE_POLICY_DEFAULT_CMP0094=NEW
+
   -DARCH=ice40
   -DBUILD_GUI=OFF
   -DICESTORM_INSTALL_PREFIX=$PREFIX

--- a/pnr/nextpnr/nexus/build.sh
+++ b/pnr/nextpnr/nexus/build.sh
@@ -7,6 +7,10 @@ RECIPE_CMAKE_ARGS=(
   # The variable set by Conda.
   $CMAKE_ARGS
 
+  # Use 'Python3_FIND_STRATEGY=LOCATION' in projects with 'cmake_minimum_required' <3.15 too.
+  # More info: https://cmake.org/cmake/help/v3.22/policy/CMP0094.html
+  -DCMAKE_POLICY_DEFAULT_CMP0094=NEW
+
   -DARCH=nexus
   -DBUILD_GUI=OFF
   -DOXIDE_INSTALL_PREFIX=$PREFIX

--- a/pnr/nextpnr/nexus/build.sh
+++ b/pnr/nextpnr/nexus/build.sh
@@ -3,8 +3,19 @@
 set -e
 set -x
 
-cmake -DARCH=nexus -DBUILD_GUI=OFF -DOXIDE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_PREFIX=/ -DENABLE_READLINE=No .
-make -k -j${CPU_COUNT} || true
-make
+RECIPE_CMAKE_ARGS=(
+  # The variable set by Conda.
+  $CMAKE_ARGS
 
+  -DARCH=nexus
+  -DBUILD_GUI=OFF
+  -DOXIDE_INSTALL_PREFIX=$PREFIX
+  -DCMAKE_INSTALL_PREFIX=/
+  )
+
+mkdir -p build
+cd build
+
+cmake ${RECIPE_CMAKE_ARGS[@]} ..
+make -k -j${CPU_COUNT} || true
 make DESTDIR=${PREFIX} install

--- a/pnr/nextpnr/xilinx/build.sh
+++ b/pnr/nextpnr/xilinx/build.sh
@@ -3,7 +3,16 @@
 set -e
 set -x
 
-cmake -DARCH=xilinx -DBUILD_GUI=OFF -DCMAKE_INSTALL_PREFIX=${PREFIX} -DENABLE_READLINE=No .
+RECIPE_CMAKE_ARGS=(
+  # The variable set by Conda.
+  $CMAKE_ARGS
+
+  -DARCH=xilinx
+  -DBUILD_GUI=OFF
+  -DCMAKE_INSTALL_PREFIX=$PREFIX
+  )
+
+cmake ${RECIPE_CMAKE_ARGS[@]} .
 make -j$(nproc)
 make install
 

--- a/pnr/nextpnr/xilinx/build.sh
+++ b/pnr/nextpnr/xilinx/build.sh
@@ -7,6 +7,10 @@ RECIPE_CMAKE_ARGS=(
   # The variable set by Conda.
   $CMAKE_ARGS
 
+  # Use 'Python3_FIND_STRATEGY=LOCATION' in projects with 'cmake_minimum_required' <3.15 too.
+  # More info: https://cmake.org/cmake/help/v3.22/policy/CMP0094.html
+  -DCMAKE_POLICY_DEFAULT_CMP0094=NEW
+
   -DARCH=xilinx
   -DBUILD_GUI=OFF
   -DCMAKE_INSTALL_PREFIX=$PREFIX


### PR DESCRIPTION
By default, CMake looks for the latest possible version of Python in the projects where CMake minimum version is less than 3.15.
Since 3.15 there's a new policy making it use the first Python found within the given version constraints.

The `nextpnr` and `prjtrellis` CMakeLists.txt allow CMake to be older than 3.15 which is why the old policy is used.
Forcing CMake to use a new policy fixes the nextpnr and prjtrellis problems with finding Python development headers on Linux.
After such a change CMake uses Conda Python which provides the headers instead of the host Python for which the headers aren't available.

There are some additional minor changes which are described in the commit messages.