### PR TITLE
nextpnr: Fix building on macOS

### DIFF
--- a/pnr/nextpnr/ecp5/build.sh
+++ b/pnr/nextpnr/ecp5/build.sh
@@ -17,6 +17,16 @@ RECIPE_CMAKE_ARGS=(
   -DCMAKE_INSTALL_PREFIX=/
   )
 
+# This addresses the following error on macOS:
+#
+# In file included from /Users/runner/work/conda-eda/conda-eda/workdir/conda-env/conda-bld/nextpnr-generic_1663768849724/work/common/place/detail_place_core.cc:20:
+#  /Users/runner/work/conda-eda/conda-eda/workdir/conda-env/conda-bld/nextpnr-generic_1663768849724/work/common/place/detail_place_core.h:102:10: error: 'shared_timed_mutex' is unavailable: introduced in macOS 10.12 - see https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
+#      std::shared_timed_mutex archapi_mutex;
+
+if [[ "$(uname -s)" == "Darwin"* ]]; then
+    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
 mkdir -p build
 cd build
 

--- a/pnr/nextpnr/fpga_interchange/build.sh
+++ b/pnr/nextpnr/fpga_interchange/build.sh
@@ -14,6 +14,16 @@ RECIPE_CMAKE_ARGS=(
   -DARCH=fpga_interchange
   )
 
+# This addresses the following error on macOS:
+#
+# In file included from /Users/runner/work/conda-eda/conda-eda/workdir/conda-env/conda-bld/nextpnr-generic_1663768849724/work/common/place/detail_place_core.cc:20:
+#  /Users/runner/work/conda-eda/conda-eda/workdir/conda-env/conda-bld/nextpnr-generic_1663768849724/work/common/place/detail_place_core.h:102:10: error: 'shared_timed_mutex' is unavailable: introduced in macOS 10.12 - see https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
+#      std::shared_timed_mutex archapi_mutex;
+
+if [[ "$(uname -s)" == "Darwin"* ]]; then
+    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
 cd nextpnr
 mkdir -p build
 cd build

--- a/pnr/nextpnr/generic/build.sh
+++ b/pnr/nextpnr/generic/build.sh
@@ -16,6 +16,16 @@ RECIPE_CMAKE_ARGS=(
   -DCMAKE_INSTALL_PREFIX=/
   )
 
+# This addresses the following error on macOS:
+#
+# In file included from /Users/runner/work/conda-eda/conda-eda/workdir/conda-env/conda-bld/nextpnr-generic_1663768849724/work/common/place/detail_place_core.cc:20:
+#  /Users/runner/work/conda-eda/conda-eda/workdir/conda-env/conda-bld/nextpnr-generic_1663768849724/work/common/place/detail_place_core.h:102:10: error: 'shared_timed_mutex' is unavailable: introduced in macOS 10.12 - see https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
+#      std::shared_timed_mutex archapi_mutex;
+
+if [[ "$(uname -s)" == "Darwin"* ]]; then
+    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
 mkdir -p build
 cd build
 

--- a/pnr/nextpnr/ice40/build.sh
+++ b/pnr/nextpnr/ice40/build.sh
@@ -17,6 +17,16 @@ RECIPE_CMAKE_ARGS=(
   -DCMAKE_INSTALL_PREFIX=/
   )
 
+# This addresses the following error on macOS:
+#
+# In file included from /Users/runner/work/conda-eda/conda-eda/workdir/conda-env/conda-bld/nextpnr-generic_1663768849724/work/common/place/detail_place_core.cc:20:
+#  /Users/runner/work/conda-eda/conda-eda/workdir/conda-env/conda-bld/nextpnr-generic_1663768849724/work/common/place/detail_place_core.h:102:10: error: 'shared_timed_mutex' is unavailable: introduced in macOS 10.12 - see https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
+#      std::shared_timed_mutex archapi_mutex;
+
+if [[ "$(uname -s)" == "Darwin"* ]]; then
+    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
 mkdir -p build
 cd build
 

--- a/pnr/nextpnr/nexus/build.sh
+++ b/pnr/nextpnr/nexus/build.sh
@@ -17,6 +17,16 @@ RECIPE_CMAKE_ARGS=(
   -DCMAKE_INSTALL_PREFIX=/
   )
 
+# This addresses the following error on macOS:
+#
+# In file included from /Users/runner/work/conda-eda/conda-eda/workdir/conda-env/conda-bld/nextpnr-generic_1663768849724/work/common/place/detail_place_core.cc:20:
+#  /Users/runner/work/conda-eda/conda-eda/workdir/conda-env/conda-bld/nextpnr-generic_1663768849724/work/common/place/detail_place_core.h:102:10: error: 'shared_timed_mutex' is unavailable: introduced in macOS 10.12 - see https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
+#      std::shared_timed_mutex archapi_mutex;
+
+if [[ "$(uname -s)" == "Darwin"* ]]; then
+    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
 mkdir -p build
 cd build
 

--- a/pnr/nextpnr/xilinx/build.sh
+++ b/pnr/nextpnr/xilinx/build.sh
@@ -16,6 +16,16 @@ RECIPE_CMAKE_ARGS=(
   -DCMAKE_INSTALL_PREFIX=$PREFIX
   )
 
+# This addresses the following error on macOS:
+#
+# In file included from /Users/runner/work/conda-eda/conda-eda/workdir/conda-env/conda-bld/nextpnr-generic_1663768849724/work/common/place/detail_place_core.cc:20:
+#  /Users/runner/work/conda-eda/conda-eda/workdir/conda-env/conda-bld/nextpnr-generic_1663768849724/work/common/place/detail_place_core.h:102:10: error: 'shared_timed_mutex' is unavailable: introduced in macOS 10.12 - see https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
+#      std::shared_timed_mutex archapi_mutex;
+
+if [[ "$(uname -s)" == "Darwin"* ]]; then
+    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
 cmake ${RECIPE_CMAKE_ARGS[@]} .
 make -j$(nproc)
 make install


### PR DESCRIPTION
The current code uses features unavailable in older macOS.

If we're about to use this code, we need to enable them anyway. Conda has a define controlling it.