### PR TITLE
Fix failing builds of vtr-optimized-linux

### DIFF
--- a/pnr/vtr-optimized/build.sh
+++ b/pnr/vtr-optimized/build.sh
@@ -39,6 +39,7 @@ BUILD_ROOT=$PWD
 # python-constraint requires to use the conda-forge channel.
 # Given that it is only used to build this package, install it via the GH repository.
 python3 -m pip install git+https://github.com/python-constraint/python-constraint.git
+python3 -m pip install https://github.com/f4pga/prjxray/archive/master.zip
 
 # Executables needed for PGO
 PGO_TARGETS="vpr genfasm"

--- a/pnr/vtr-optimized/condarc
+++ b/pnr/vtr-optimized/condarc
@@ -1,2 +1,3 @@
 channels:
   - defaults
+  - litex-hub

--- a/pnr/vtr-optimized/meta.yaml
+++ b/pnr/vtr-optimized/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   - git_url: https://github.com/verilog-to-routing/vtr-verilog-to-routing.git
     git_rev: master
+    patches:
+      vpr-cmake.patch
   - path: . # Extra files needed for PGO
 
 build:
@@ -31,15 +33,18 @@ requirements:
     - intervaltree
     - curl
     - xz
+    - pyyaml
   host:
     - bison
     - cmake
     - flex
     - pkg-config
-    - tbb <2021.0.0a0
-    - tbb-devel <2021.0.0a0
+    - prjxray-db
+    - prjxray-tools
+    - tbb
+    - tbb-devel
   run:
-    - tbb <2021.0.0a0
+    - tbb
 
 about:
   home: http://verilogtorouting.org/

--- a/pnr/vtr-optimized/vpr-cmake.patch
+++ b/pnr/vtr-optimized/vpr-cmake.patch
@@ -1,0 +1,12 @@
+diff --git a/vpr/CMakeLists.txt b/vpr/CMakeLists.txt
+index 05f82edde..6da113bf3 100644
+--- a/vpr/CMakeLists.txt
++++ b/vpr/CMakeLists.txt
+@@ -151,6 +151,7 @@ set(PROF_GEN_FLAGS_TO_CHECK
+ set(PROF_USE_FLAGS_TO_CHECK
+     #GCC-like
+     "-fprofile-use=${VPR_PGO_DATA_DIR}"     #Build will use previously generated profiling information to guide code optimization
++    "-fprofile-correction" #correct the profile
+     "-Wmissing-profile" #Warn if the used profiling information doesn't match the source code or is missing
+     )
+ 


### PR DESCRIPTION
The goal of this PR is to fix failing builds of 'vtr-optimized-linux' package. Changes made:
* install latest tbb version instead of '<2021.0.0a0'
* install prjxray, prjxray-db, prjxray-tools, pyyaml
* add litex-hub channel to condarc (needed for prjxray-db, prjxray-tools)
* add vpr-cmake.patch for the vtr repo with the -fprofile-correction flag