### PR TITLE
ci/conda-get: use bash to run miniconda

### DIFF
--- a/ci/conda-get.sh
+++ b/ci/conda-get.sh
@@ -21,7 +21,7 @@ else
     wget --progress=dot:giga -c https://repo.continuum.io/miniconda/Miniconda3-latest-${sys_name}-x86_64.sh
     chmod a+x Miniconda3-latest-${sys_name}-x86_64.sh
     if [ ! -d $CONDA_PATH -o ! -z "$CI"  ]; then
-            ./Miniconda3-latest-${sys_name}-x86_64.sh -p $CONDA_PATH -b -f
+            bash Miniconda3-latest-${sys_name}-x86_64.sh -p $CONDA_PATH -b -f
     fi
     export PATH=$CONDA_PATH/bin:$PATH
 fi


### PR DESCRIPTION
Looks like miniconda started using bashism:
```
  ./Miniconda3-latest-Linux-x86_64.sh: 444: [[: not found
```

See https://github.com/google/CFU-Playground/issues/752