### PR TITLE
sim: add ngspice

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -751,3 +751,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./ci
+
+  #66
+  ngspice-linux:
+    runs-on: "ubuntu-20.04"
+    env:
+      PACKAGE: "sim/ngspice"
+      OS_NAME: "linux"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./ci
+        

--- a/sim/ngspice/build.sh
+++ b/sim/ngspice/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+set -x
+
+./autogen.sh
+./configure --prefix="${PREFIX}" --disable-debug
+make V=1 -j$CPU_COUNT
+make V=1 install

--- a/sim/ngspice/meta.yaml
+++ b/sim/ngspice/meta.yaml
@@ -1,0 +1,45 @@
+# Use `conda-build-prepare` before building for a better version string.
+{% set NGSPICE_TAG = GIT_DESCRIBE_TAG|replace('ngspice-', '') %}
+{% set version = '%s_%04i_%s'|format(NGSPICE_TAG, GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
+package:
+  name: ngspice
+  version: {{ version }}
+
+source:
+   git_url: git://git.code.sf.net/p/ngspice/ngspice
+   git_rev: master
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+
+requirements:
+  build:
+    - autoconf
+    - automake
+    - make
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+
+test:
+  commands:
+    - ngspice --version
+
+about:
+  home: https://ngspice.sourceforge.io/
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: COPYING
+  summary: 'The open source spice simulator for electric and electronic circuit.'
+  description: |
+    Ngspice is the open source spice simulator for electric and electronic circuits.
+
+    Such a circuit may comprise of JFETs, bipolar and MOS transistors, passive elements like R, L, or C, diodes, transmission lines and other devices, all interconnected in a netlist. Digital circuits are simulated as well, event driven and fast, from single gates to complex circuits. And you may enter the combination of both analog and digital as a mixed-signal circuit.
+
+    ngspice offers a wealth of device models for active, passive, analog, and digital elements. Model parameters are provided by our collections, by the semiconductor device manufacturers, or from semiconductor foundries. The user adds her circuits as a netlist, and the output is one or more graphs of currents, voltages and other electrical quantities or is saved in a data file.
+     tools for their product design flow.
+  doc_url: https://ngspice.sourceforge.io/docs.html
+  dev_url: http://ngspice.sourceforge.net/devel.html


### PR DESCRIPTION
This a simpler version than https://github.com/conda-forge/ngspice-feedstock maintained @stuarteberg with minimal dependencies and no gui (see #193 and #250 for rational).

This will allow us to build an installer for the sky130/gf180 analog flow (per #245).

Fixes #49. 