### PR TITLE
Disable interprocedural optimization for VTR

### DIFF
--- a/pnr/vtr-gui/build.sh
+++ b/pnr/vtr-gui/build.sh
@@ -13,7 +13,7 @@ case "${UNAME_OUT}" in
                 exit;;
 esac
 
-make V=1 CMAKE_PARAMS="-DCMAKE_INSTALL_PREFIX=${PREFIX}" -j$CPU_COUNT
+make V=1 CMAKE_PARAMS="-DCMAKE_INSTALL_PREFIX=${PREFIX} -DVTR_IPO_BUILD=off" -j$CPU_COUNT
 if [[ $OS != "Mac" ]]; then
 	make test
 fi


### PR DESCRIPTION
By default the `CMAKE_INTERPROCEDURAL_OPTIMIZATION` flag is on for VTR, this may cause `LTO` version incompatibility when using the binaries out of `VTR` scope in other projects.
Thir PR disables `INTERPROCEDURAL_OPTIMIZATION` for `VTR` package while installing by turning off the `VTR_IPO_BUILD` flag in the build script.