### PR TITLE
CI: Only build the OpenLane package if building Open-PDKs succeeded

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -722,7 +722,7 @@ jobs:
 
   #64
   openlane-linux:
-    needs: ["magic-linux", "netgen-linux", "openroad-linux", "yosys-linux-py37", "yosys-linux-py38"]
+    needs: ["magic-linux", "netgen-linux", "open_pdks-linux", "openroad-linux", "yosys-linux-py37", "yosys-linux-py38"]
     runs-on: "ubuntu-20.04"
     env:
       PACKAGE: "misc/openlane"


### PR DESCRIPTION
This change will ensure a problem when testing OpenLane in the same CI that:
* built a new version of the magic package,
* failed to build `open_pdks` with that new magic version
won't happen again since debugging this isn't trivial.

It turned out all of the open_pdks packages newer than 1.0.286 have a strict magic version requirement. The just-built magic package will be always preferred in CI so when building `open_pdks` fail and the CI built a new version of the magic package then this old `1.0.286` Open-PDKs package will be used which doesn't work well with the other latest packages.

Such a run happened in https://github.com/hdl/conda-eda/actions/runs/3828789250/jobs/6551196431#step:7:3305