### PR TITLE
readme: update shield syntax (badges/shields#8671)

### DIFF
--- a/docs/shields.inc
+++ b/docs/shields.inc
@@ -1,35 +1,35 @@
-.. |SHIELD:svg:CI:eda:Upload| image:: https://img.shields.io/github/workflow/status/hdl/conda-eda/Upload%20packages/master?longCache=true&style=flat-square&label=Upload%20packages&logo=Github%20Actions&logoColor=fff
+.. |SHIELD:svg:CI:eda:Upload| image:: https://img.shields.io/github/actions/workflow/status/hdl/conda-eda/Upload%20packages.yml?branch=master&longCache=true&style=flat-square&label=Upload%20packages&logo=Github%20Actions&logoColor=fff
    :alt: GitHub Actions workflow 'Upload'
    :height: 22
    :target: https://github.com/hdl/conda-eda/actions/workflows/Upload.yml
-.. |SHIELD:png:CI:eda:Upload| image:: https://raster.shields.io/github/workflow/status/hdl/conda-eda/Upload%20packages/master?longCache=true&style=flat-square&label=Upload%20packages&logo=Github%20Actions&logoColor=fff
+.. |SHIELD:png:CI:eda:Upload| image:: https://raster.shields.io/github/workflow/status/hdl/conda-eda/Upload%20packages.yml?branch=master&longCache=true&style=flat-square&label=Upload%20packages&logo=Github%20Actions&logoColor=fff
    :alt: GitHub Actions workflow 'Upload'
    :height: 22
    :target: https://github.com/hdl/conda-eda/actions/workflows/Upload.yml
 
-.. |SHIELD:svg:CI:compilers:Upload| image:: https://img.shields.io/github/workflow/status/hdl/conda-compilers/Upload%20packages/master?longCache=true&style=flat-square&label=Upload%20packages&logo=Github%20Actions&logoColor=fff
+.. |SHIELD:svg:CI:compilers:Upload| image:: https://img.shields.io/github/actions/workflow/status/hdl/conda-compilers/Upload%20packages.yml?branch=master&longCache=true&style=flat-square&label=Upload%20packages&logo=Github%20Actions&logoColor=fff
    :alt: GitHub Actions workflow 'Upload'
    :height: 22
    :target: https://github.com/hdl/conda-compilers/actions/workflows/Upload.yml
-.. |SHIELD:png:CI:compilers:Upload| image:: https://raster.shields.io/github/workflow/status/hdl/conda-compilers/Upload%20packages/master?longCache=true&style=flat-square&label=Upload%20packages&logo=Github%20Actions&logoColor=fff
+.. |SHIELD:png:CI:compilers:Upload| image:: https://raster.shields.io/github/workflow/status/hdl/conda-compilers/Upload%20packages.yml?branch=master&longCache=true&style=flat-square&label=Upload%20packages&logo=Github%20Actions&logoColor=fff
    :alt: GitHub Actions workflow 'Upload'
    :height: 22
    :target: https://github.com/hdl/conda-compilers/actions/workflows/Upload.yml
 
-.. |SHIELD:svg:CI:misc:Upload| image:: https://img.shields.io/github/workflow/status/hdl/conda-misc/Upload%20packages/master?longCache=true&style=flat-square&label=Upload%20packages&logo=Github%20Actions&logoColor=fff
+.. |SHIELD:svg:CI:misc:Upload| image:: https://img.shields.io/github/actions/workflow/status/hdl/conda-misc/Upload%20packages.yml?branch=master&longCache=true&style=flat-square&label=Upload%20packages&logo=Github%20Actions&logoColor=fff
    :alt: GitHub Actions workflow 'Upload'
    :height: 22
    :target: https://github.com/hdl/conda-misc/actions/workflows/Upload.yml
-.. |SHIELD:png:CI:misc:Upload| image:: https://raster.shields.io/github/workflow/status/hdl/conda-misc/Upload%20packages/master?longCache=true&style=flat-square&label=Upload%20packages&logo=Github%20Actions&logoColor=fff
+.. |SHIELD:png:CI:misc:Upload| image:: https://raster.shields.io/github/workflow/status/hdl/conda-misc/Upload%20packages.yml?branch=master&longCache=true&style=flat-square&label=Upload%20packages&logo=Github%20Actions&logoColor=fff
    :alt: GitHub Actions workflow 'Upload'
    :height: 22
    :target: https://github.com/hdl/conda-misc/actions/workflows/Upload.yml
 
-.. |SHIELD:svg:CI:prog:Upload| image:: https://img.shields.io/github/workflow/status/hdl/conda-prog/Upload%20packages/master?longCache=true&style=flat-square&label=Upload%20packages&logo=Github%20Actions&logoColor=fff
+.. |SHIELD:svg:CI:prog:Upload| image:: https://img.shields.io/github/actions/workflow/status/hdl/conda-prog/Upload%20packages.yml?branch=master&longCache=true&style=flat-square&label=Upload%20packages&logo=Github%20Actions&logoColor=fff
    :alt: GitHub Actions workflow 'Upload'
    :height: 22
    :target: https://github.com/hdl/conda-prog/actions/workflows/Upload.yml
-.. |SHIELD:png:CI:prog:Upload| image:: https://raster.shields.io/github/workflow/status/hdl/conda-prog/Upload%20packages/master?longCache=true&style=flat-square&label=Upload%20packages&logo=Github%20Actions&logoColor=fff
+.. |SHIELD:png:CI:prog:Upload| image:: https://raster.shields.io/github/workflow/status/hdl/conda-prog/Upload%20packages.yml?branch=master&longCache=true&style=flat-square&label=Upload%20packages&logo=Github%20Actions&logoColor=fff
    :alt: GitHub Actions workflow 'Upload'
    :height: 22
    :target: https://github.com/hdl/conda-prog/actions/workflows/Upload.yml


### PR DESCRIPTION
This PR updates the syntax of the broken shield/badge in the readme. See https://github.com/badges/shields/issues/8671.