### PR TITLE
Use custom runners

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -11,243 +11,262 @@ on:
 env:
   ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
   ANACONDA_USER: ${{ secrets.ANACONDA_USER }}
+  DEBIAN_FRONTEND: noninteractive
+  GHA_MACHINE_TYPE: "n2-standard-4"
+  APT_REQUIREMENTS: binutils build-essential csh curl git libgl1 pkg-config sudo wget
 
 defaults:
   run:
     shell: bash
 
 jobs:
-
-  #1
   magic-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "misc/magic"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
-      - name: 'Install csh'
-        run: |
-          sudo apt update
-          sudo apt install -y csh
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }} libxrender1
       - uses: ./ci
 
-  #2
   icestorm-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "bit/icestorm"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #3
   prjtrellis-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "bit/prjtrellis"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #4
   prjoxide-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "bit/prjoxide"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #5
   prjxray-db-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "bit/prjxray-db"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #6
   prjxray-tools-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "bit/prjxray-tools"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #7
   icarus-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "sim/icarus"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #8
   verilator-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "sim/verilator"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #9
   yosys-linux-py37:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "syn/yosys"
       OS_NAME: "linux"
       PYTHON_VERSION: "3.7"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #10
   yosys-linux-py38:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "syn/yosys"
       OS_NAME: "linux"
       PYTHON_VERSION: "3.8"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #11
   yosys-plugins-symbiflow-linux:
-    runs-on: "ubuntu-20.04"
     needs: ["icarus-linux", "yosys-linux-py37", "yosys-linux-py38", "surelog-linux-py37", "surelog-linux-py38"]
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "syn/yosys-plugins-symbiflow"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #12
   nextpnr-nexus-linux:
-    runs-on: "ubuntu-20.04"
     needs: ["prjoxide-linux"]
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "pnr/nextpnr/nexus"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #13
   symbiflow-yosys-plugins-linux:
-    runs-on: "ubuntu-20.04"
     needs: ["icarus-linux", "yosys-linux-py37", "yosys-linux-py38", "surelog-linux-py37", "surelog-linux-py38"]
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "syn/symbiflow-yosys-plugins"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #14
   vtr-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "pnr/vtr"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #15
   vtr-gui-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "pnr/vtr-gui"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #16
   vtr-optimized-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "pnr/vtr-optimized"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #17
   quicklogic-vtr-linux:
-    runs-on: "ubuntu-20.04"
-    needs: "vtr-linux"
+    needs: ["vtr-linux"]
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "pnr/quicklogic-vtr"
       OS_NAME: "linux"
     steps:
-      # Skip if token isn't available (cross-repository PRs mainly)
-      - run: if [ "$ANACONDA_TOKEN" = "" ]; then echo "SKIP=true" >>$GITHUB_ENV; fi
       - uses: actions/checkout@v3
+      # Skip if token isn't available (cross-repository PRs mainly).
+      - run: if [ "$ANACONDA_TOKEN" = "" ]; then echo "SKIP=true" >>$GITHUB_ENV; fi
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #18
   quicklogic-vtr-gui-linux:
-    runs-on: "ubuntu-20.04"
-    needs: "vtr-gui-linux"
+    needs: ["vtr-gui-linux"]
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "pnr/quicklogic-vtr-gui"
       OS_NAME: "linux"
     steps:
-      # Skip if token isn't available (cross-repository PRs mainly)
-      - run: if [ "$ANACONDA_TOKEN" = "" ]; then echo "SKIP=true" >>$GITHUB_ENV; fi
       - uses: actions/checkout@v3
+      # Skip if token isn't available (cross-repository PRs mainly).
+      - run: if [ "$ANACONDA_TOKEN" = "" ]; then echo "SKIP=true" >>$GITHUB_ENV; fi
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #19
   nextpnr-ice40-linux:
-    runs-on: "ubuntu-20.04"
     needs: ["icestorm-linux"]
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "pnr/nextpnr/ice40"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #20
   nextpnr-ecp5-linux:
-    runs-on: "ubuntu-20.04"
     needs: ["prjtrellis-linux"]
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "pnr/nextpnr/ecp5"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #21
   nextpnr-generic-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "pnr/nextpnr/generic"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #22
   nextpnr-xilinx-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "pnr/nextpnr/xilinx"
       OS_NAME: "linux"
@@ -256,27 +275,26 @@ jobs:
       SKIP: "true"  # See https://github.com/hdl/conda-eda/issues/191
     steps:
       - uses: actions/checkout@v3
-      - name: 'Install pypy'
-        run: |
-          sudo add-apt-repository ppa:pypy/ppa -y
-          sudo apt update
-          sudo apt install -y pypy3
+      - run: apt -qqy update && apt -qqy install software-properties-common
+      - run: add-apt-repository ppa:pypy/ppa
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }} pypy
       - uses: ./ci
 
-  #23
   nextpnr-fpga_interchange-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "pnr/nextpnr/fpga_interchange"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #24
   symbiyosys-linux-py37:
-    runs-on: "ubuntu-20.04"
-    needs: "yosys-linux-py37"
+    needs: ["yosys-linux-py37"]
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "formal/symbiyosys"
       OS_NAME: "linux"
@@ -284,12 +302,13 @@ jobs:
       SKIP: "true"  # See https://github.com/litex-hub/litex-conda-eda/issues/70
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #25
   symbiyosys-linux-py38:
-    runs-on: "ubuntu-20.04"
-    needs: "yosys-linux-py38"
+    needs: ["yosys-linux-py38"]
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "formal/symbiyosys"
       OS_NAME: "linux"
@@ -297,11 +316,12 @@ jobs:
       SKIP: "true"  # See https://github.com/litex-hub/litex-conda-eda/issues/70
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #26
   xilinx-vivado-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "xilinx/vivado"
       OS_NAME: "linux"
@@ -309,9 +329,9 @@ jobs:
       SCRIPT: ${{ format('{0}{1}', github.workspace, '/xilinx/vivado/gen_metapackages.sh') }}
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #27
   icestorm-osx:
     runs-on: "macos-latest"
     env:
@@ -321,7 +341,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #28
   prjtrellis-osx:
     runs-on: "macos-latest"
     env:
@@ -331,7 +350,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #29
   icarus-osx:
     runs-on: "macos-latest"
     env:
@@ -341,7 +359,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #30
   verilator-osx:
     runs-on: "macos-latest"
     env:
@@ -351,7 +368,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #31
   yosys-osx:
     runs-on: "macos-latest"
     env:
@@ -362,7 +378,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #32
   symbiflow-yosys-plugins-osx:
     runs-on: "macos-latest"
     needs: ["icarus-osx", "yosys-osx"]
@@ -374,7 +389,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #33
   vtr-osx:
     runs-on: "macos-latest"
     env:
@@ -385,7 +399,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #34
   vtr-gui-osx:
     runs-on: "macos-latest"
     env:
@@ -396,7 +409,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #35
   nextpnr-ice40-osx:
     runs-on: "macos-latest"
     needs: ["icestorm-osx"]
@@ -407,7 +419,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #36
   nextpnr-generic-osx:
     runs-on: "macos-latest"
     env:
@@ -417,7 +428,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #37
   icestorm-windows:
     runs-on: "windows-latest"
     env:
@@ -428,7 +438,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #38
   prjtrellis-windows:
     runs-on: "windows-latest"
     env:
@@ -439,7 +448,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #39
   icarus-windows:
     runs-on: "windows-latest"
     env:
@@ -450,7 +458,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #40
   yosys-windows:
     runs-on: "windows-latest"
     env:
@@ -461,7 +468,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #41
   nextpnr-ice40-windows:
     runs-on: "windows-latest"
     needs: ["icestorm-windows"]
@@ -473,7 +479,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #42
   nextpnr-generic-windows:
     runs-on: "windows-latest"
     env:
@@ -484,7 +489,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #43
   verible-linux:
     runs-on: "ubuntu-20.04"
     env:
@@ -495,28 +499,29 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #44
   tree-sitter-verilog-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "misc/tree-sitter-verilog"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #45
   odin-ii-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "pnr/odin_II"
       OS_NAME: "linux"
       SKIP: "true"  # See https://github.com/hdl/conda-eda/issues/209
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }} libgmp-dev
       - uses: ./ci
 
-  #46
   slang-linux:
     runs-on: "ubuntu-20.04"
     env:
@@ -527,55 +532,59 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
-  #47
   sv-parser-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "sv-front/sv-parser"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #48
   moore-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "sv-front/moore"
       OS_NAME: "linux"
       SKIP: "true"  # See https://github.com/hdl/conda-eda/issues/163
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #49
   surelog-linux-py37:
     needs: ["libunwind", "gperftools"]
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "sv-front/surelog"
       OS_NAME: "linux"
       PYTHON_VERSION: "3.7"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #50
   surelog-linux-py38:
     needs: ["libunwind", "gperftools"]
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "sv-front/surelog"
       OS_NAME: "linux"
       PYTHON_VERSION: "3.8"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #51
   surelog-uhdm-linux-py37:
     needs: ["libunwind", "gperftools"]
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "sv-front/surelog-uhdm"
       USE_SYSTEM_GCC_VERSION: "9"
@@ -583,12 +592,13 @@ jobs:
       PYTHON_VERSION: "3.7"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }} default-jre
       - uses: ./ci
 
-  #52
   surelog-uhdm-linux-py38:
     needs: ["libunwind", "gperftools"]
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "sv-front/surelog-uhdm"
       USE_SYSTEM_GCC_VERSION: "9"
@@ -596,169 +606,184 @@ jobs:
       PYTHON_VERSION: "3.8"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }} default-jre
       - uses: ./ci
 
-  #53
   yosys-uhdm-linux-py37:
     needs: ["libunwind", "gperftools"]
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "syn/yosys-uhdm"
       OS_NAME: "linux"
       PYTHON_VERSION: "3.7"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #54
   yosys-uhdm-linux-py38:
     needs: ["libunwind", "gperftools"]
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "syn/yosys-uhdm"
       OS_NAME: "linux"
       PYTHON_VERSION: "3.8"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #55
   libunwind:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "misc/libunwind"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #56
   gperftools:
-    needs: "libunwind"
-    runs-on: "ubuntu-20.04"
+    needs: ["libunwind"]
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "misc/gperftools"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #57
   verilator-uhdm-linux-py37:
     needs: ["gperftools"]
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "sim/verilator-uhdm"
       OS_NAME: "linux"
       PYTHON_VERSION: "3.7"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }} default-jre
       - uses: ./ci
 
-  #58
   verilator-uhdm-linux-py38:
     needs: ["gperftools"]
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "sim/verilator-uhdm"
       OS_NAME: "linux"
       PYTHON_VERSION: "3.8"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }} default-jre
       - uses: ./ci
 
-  #59
   netgen-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "misc/netgen"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #60
   zachjs-sv2v-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "sv-front/zachjs-sv2v"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }} libgmp-dev
       - uses: ./ci
 
-  #61
   open_pdks-linux:
-    runs-on: "ubuntu-20.04"
     needs: ["magic-linux"]
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "misc/open_pdks"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }} libxrender1
       - uses: ./ci
 
-  #62
   openroad-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "pnr/openroad"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #63
   xls-linux:
+    runs-on: [self-hosted, Linux, X64]
     # uses older ubuntu for better compat:
     # https://github.com/hdl/conda-eda/issues/199
-    runs-on: "ubuntu-18.04"
+    container: ubuntu:18.04
     env:
       PACKAGE: "hls/xls"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #64
   openlane-linux:
     needs: ["magic-linux", "netgen-linux", "openroad-linux", "yosys-linux-py37", "yosys-linux-py38"]
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "misc/openlane"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }} libxrender1
       - uses: ./ci
 
-  #65
   xschem-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "misc/xschem"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }} xorg-dev tcl-dev
       - uses: ./ci
 
-  #66
   klayout-linux-py37:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "misc/klayout"
       OS_NAME: "linux"
       PYTHON_VERSION: "3.7"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
 
-  #66
   ngspice-linux:
-    runs-on: "ubuntu-20.04"
+    runs-on: [self-hosted, Linux, X64]
+    container: ubuntu:20.04
     env:
       PACKAGE: "sim/ngspice"
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v3
+      - run: apt -qqy update && apt -qqy install ${{ env.APT_REQUIREMENTS }}
       - uses: ./ci
-        

--- a/bit/prjoxide/build.sh
+++ b/bit/prjoxide/build.sh
@@ -11,6 +11,7 @@ pushd capnproto-c++-0.8.0
 ./configure
 make -j`nproc` check
 sudo make install
+export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
 popd
 
 git clone https://github.com/capnproto/capnproto-java.git
@@ -20,6 +21,7 @@ sudo make install
 popd
 
 curl --proto '=https' -sSf https://sh.rustup.rs | sh -s -- -y
+source "$HOME/.cargo/env"
 
 cd libprjoxide
 cargo install --path prjoxide --all-features --root $PREFIX

--- a/bit/prjoxide/meta.yaml
+++ b/bit/prjoxide/meta.yaml
@@ -21,6 +21,11 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - autoconf
+    - libtool
+    - make
+    - binutils
+    - pkg-config
 
 about:
   home: https://github.com/gatecat/prjoxide

--- a/ci/common.sh
+++ b/ci/common.sh
@@ -138,6 +138,11 @@ if [ -d "workdir/recipe" ]; then
     fi
 fi
 
+# ssh: Disable host key checking
+mkdir -p ~/.ssh
+echo "Host *" >> ~/.ssh/config
+echo "    StrictHostKeyChecking no" >> ~/.ssh/config
+
 echo "          GITREV: $GITREV"
 echo "      CONDA_PATH: $CONDA_PATH"
 echo "CONDA_BUILD_ARGS: $CONDA_BUILD_ARGS"

--- a/misc/tree-sitter-verilog/meta.yaml
+++ b/misc/tree-sitter-verilog/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - {{ compiler('cxx') }}
     - nodejs
     - python
+    - make
 
 about:
   home: https://github.com/tree-sitter/tree-sitter-verilog

--- a/misc/xschem/meta.yaml
+++ b/misc/xschem/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - make
     - bison
     - flex
+    - tk
     - {{ compiler('c') }}
     - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
     - {{ cdt('libx11-devel') }}  # [linux]

--- a/sim/ngspice/meta.yaml
+++ b/sim/ngspice/meta.yaml
@@ -20,7 +20,9 @@ requirements:
   build:
     - autoconf
     - automake
+    - libtool
     - make
+    - bison
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
 

--- a/sim/verilator-uhdm/meta.yaml
+++ b/sim/verilator-uhdm/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - bison
+    - automake
     - cmake
     - pkg-config
     - orderedmultidict

--- a/sim/verilator/meta.yaml
+++ b/sim/verilator/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - gxx_linux-64 >=8      [linux]
     - autoconf
     - make
+    - help2man
   host:
     - bison
     - flex

--- a/sv-front/surelog/meta.yaml
+++ b/sv-front/surelog/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - libunwind
     - swig
     - orderedmultidict
+    - openjdk
 
   run:
     - python {{ python_version }}

--- a/sv-front/sv-parser/meta.yaml
+++ b/sv-front/sv-parser/meta.yaml
@@ -17,6 +17,11 @@ build:
   script_env:
     - CI
 
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+
 test:
   commands:
     - parse_sv --version

--- a/syn/yosys-uhdm/build.sh
+++ b/syn/yosys-uhdm/build.sh
@@ -17,5 +17,5 @@ cd Surelog && \
 unset CXX CXXFLAGS LDLIBS LDFLAGS
 
 make -C yosys ENABLE_READLINE=0 CONFIG=conda-linux PROGRAM_PREFIX=uhdm- install -j$(nproc)
-make -C $PWD/yosys-symbiflow-plugins/ UHDM_INSTALL_DIR=$PREFIX install -j$(nproc)
+make -C yosys-f4pga-plugins/ UHDM_INSTALL_DIR=$PREFIX install -j$(nproc)
 

--- a/syn/yosys-uhdm/uhdm-plugin.patch
+++ b/syn/yosys-uhdm/uhdm-plugin.patch
@@ -1,10 +1,11 @@
-diff --git a/yosys-symbiflow-plugins/Makefile_plugin.common b/yosys-symbiflow-plugins/Makefile_plugin.common
-index fd6d86e..7376e41 100644
---- a/yosys-symbiflow-plugins/Makefile_plugin.common
-+++ b/yosys-symbiflow-plugins/Makefile_plugin.common
-@@ -40,13 +40,13 @@
+Submodule yosys-f4pga-plugins contains modified content
+diff --git a/yosys-f4pga-plugins/Makefile_plugin.common b/yosys-f4pga-plugins/Makefile_plugin.common
+index 45c2640..9b838e0 100644
+--- a/yosys-f4pga-plugins/Makefile_plugin.common
++++ b/yosys-f4pga-plugins/Makefile_plugin.common
+@@ -46,13 +46,13 @@ TOP_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
  
- SHELL := /usr/bin/env bash
+ _MAKEFILES := $(abspath $(filter-out %.d,$(MAKEFILE_LIST)))
  
 -# Either find yosys in system and use its path or use the given path
 -YOSYS_PATH ?= $(realpath $(dir $(shell command -v yosys))/..)
@@ -21,10 +22,10 @@ index fd6d86e..7376e41 100644
  endif
  
  CXX ?= $(shell $(YOSYS_CONFIG) --cxx)
-diff --git a/yosys-symbiflow-plugins/Makefile_test.common b/yosys-symbiflow-plugins/Makefile_test.common
+diff --git a/yosys-f4pga-plugins/Makefile_test.common b/yosys-f4pga-plugins/Makefile_test.common
 index 5d72327..75096de 100644
---- a/yosys-symbiflow-plugins/Makefile_test.common
-+++ b/yosys-symbiflow-plugins/Makefile_test.common
+--- a/yosys-f4pga-plugins/Makefile_test.common
++++ b/yosys-f4pga-plugins/Makefile_test.common
 @@ -16,13 +16,13 @@
  
  SHELL := /usr/bin/env bash

--- a/syn/yosys/makefile-conda-config.patch
+++ b/syn/yosys/makefile-conda-config.patch
@@ -1,10 +1,10 @@
 diff --git a/Makefile b/Makefile
-index b37d11c05..c6725d88a 100644
+index ca8bc1cb5..8d7171bb0 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -378,6 +378,20 @@ ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -DWIN32_NO_DLL -DHAVE_STRUCT_TIMESPEC
- ABCMKARGS += LIBS="-lpthread -s" ABC_USE_NO_READLINE=0 CC="x86_64-w64-mingw32-gcc" CXX="$(CXX)"
- EXE = .exe
+@@ -220,6 +220,20 @@ LD = clang++
+ CXXFLAGS += -std=$(CXXSTD) -Os
+ ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -Wno-c++11-narrowing $(ABC_ARCHFLAGS)"
  
 +else ifeq ($(CONFIG),conda-linux)
 +CXX = $(notdir $(CC))
@@ -20,10 +20,10 @@ index b37d11c05..c6725d88a 100644
 +CXXFLAGS += -std=c++11 -Os
 +ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H"
 +
- else ifneq ($(CONFIG),none)
- $(error Invalid CONFIG setting '$(CONFIG)'. Valid values: clang, gcc, gcc-4.8, emcc, mxe, msys2-32, msys2-64)
- endif
-@@ -597,6 +611,11 @@ EXTRA_OBJS += $(1)
+ ifneq ($(SANITIZER),)
+ $(info [Clang Sanitizer] $(SANITIZER))
+ CXXFLAGS += -g -O1 -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=$(SANITIZER)
+@@ -590,6 +604,11 @@ EXTRA_OBJS += $(1)
  .SECONDARY: $(1)
  endef
  
@@ -35,9 +35,9 @@ index b37d11c05..c6725d88a 100644
  ifeq ($(PRETTY), 1)
  P_STATUS = 0
  P_OFFSET = 0
-@@ -1099,6 +1118,12 @@ config-gprof: clean
- 	echo 'CONFIG := gcc' > Makefile.conf
- 	echo 'ENABLE_GPROF := 1' >> Makefile.conf
+@@ -1047,6 +1066,12 @@ config-gcc-static: clean
+ 	echo 'ENABLE_READLINE := 0' >> Makefile.conf
+ 	echo 'ENABLE_TCL := 0' >> Makefile.conf
  
 +config-conda-linux: clean
 +	echo 'CONFIG := conda-linux' > Makefile.conf
@@ -45,12 +45,11 @@ index b37d11c05..c6725d88a 100644
 +config-conda-mac: clean
 +	echo 'CONFIG := conda-mac' > Makefile.conf
 +
- config-sudo:
- 	echo "INSTALL_SUDO := sudo" >> Makefile.conf
+ config-afl-gcc: clean
+ 	echo 'CONFIG := afl-gcc' > Makefile.conf
  
-@@ -1119,4 +1144,4 @@ echo-abc-rev:
- -include techlibs/*/*.d
+@@ -1111,3 +1136,4 @@ echo-abc-rev:
  
  .PHONY: all top-all abc test install install-abc docs clean mrproper qtcreator coverage vcxsrc mxebin
--.PHONY: config-clean config-clang config-gcc config-gcc-static config-gcc-4.8 config-afl-gcc config-gprof config-sudo
-+.PHONY: config-clean config-clang config-gcc config-gcc-static config-gcc-4.8 config-afl-gcc config-gprof config-sudo config-conda-linux config-conda-mac
+ .PHONY: config-clean config-clang config-gcc config-gcc-static config-afl-gcc config-gprof config-sudo
++.PHONY: config-gprof config-conda-linux config-conda-mac config-sudo


### PR DESCRIPTION
This PR migrates package builds for Linux to GHA custom runners.

The runners have less software installed by default, which resulted in the need make changes in some build scripts and requirements lists.
