### PR TITLE
Update Verilator tests

### DIFF
--- a/sim/verilator/run_test.sh
+++ b/sim/verilator/run_test.sh
@@ -27,7 +27,7 @@ int main(int argc, char **argv, char **env) {
     exit(0);
 }
 EOF
-	$PREFIX/bin/verilator --cc --trace-fst \
+	$PREFIX/bin/verilator --cc --trace-fst --no-std \
             $FILENAME.v $2 $3 --exe sim_main.cpp
 	cd obj_dir
 	cat V$FILENAME.mk


### PR DESCRIPTION
Verilator is run without proper installation, therefore it cannot find the std library.