### PR TITLE
Add support for yosys and iverilog on osx arm64

### DIFF
--- a/sim/icarus/add-arm64.patch
+++ b/sim/icarus/add-arm64.patch
@@ -1,0 +1,3118 @@
+diff --git a/config.sub b/config.sub
+index 8f1229c6f..d74fb6dea 100755
+--- a/config.sub
++++ b/config.sub
+@@ -1,8 +1,10 @@
+ #! /bin/sh
+ # Configuration validation subroutine script.
+-#   Copyright 1992-2015 Free Software Foundation, Inc.
++#   Copyright 1992-2021 Free Software Foundation, Inc.
+ 
+-timestamp='2015-03-08'
++# shellcheck disable=SC2006,SC2268 # see below for rationale
++
++timestamp='2021-08-14'
+ 
+ # This file is free software; you can redistribute it and/or modify it
+ # under the terms of the GNU General Public License as published by
+@@ -15,7 +17,7 @@ timestamp='2015-03-08'
+ # General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License
+-# along with this program; if not, see <http://www.gnu.org/licenses/>.
++# along with this program; if not, see <https://www.gnu.org/licenses/>.
+ #
+ # As a special exception to the GNU General Public License, if you
+ # distribute this file as part of a program that contains a
+@@ -33,7 +35,7 @@ timestamp='2015-03-08'
+ # Otherwise, we print the canonical config type on stdout and succeed.
+ 
+ # You can get the latest version of this script from:
+-# http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD
++# https://git.savannah.gnu.org/cgit/config.git/plain/config.sub
+ 
+ # This file is supposed to be the same for all GNU packages
+ # and recognize all the CPU types, system types and aliases
+@@ -50,15 +52,21 @@ timestamp='2015-03-08'
+ #	CPU_TYPE-MANUFACTURER-KERNEL-OPERATING_SYSTEM
+ # It is wrong to echo any other type of specification.
+ 
++# The "shellcheck disable" line above the timestamp inhibits complaints
++# about features and limitations of the classic Bourne shell that were
++# superseded or lifted in POSIX.  However, this script identifies a wide
++# variety of pre-POSIX systems that do not have POSIX shells at all, and
++# even some reasonably current systems (Solaris 10 as case-in-point) still
++# have a pre-POSIX /bin/sh.
++
+ me=`echo "$0" | sed -e 's,.*/,,'`
+ 
+ usage="\
+-Usage: $0 [OPTION] CPU-MFR-OPSYS
+-       $0 [OPTION] ALIAS
++Usage: $0 [OPTION] CPU-MFR-OPSYS or ALIAS
+ 
+ Canonicalize a configuration name.
+ 
+-Operation modes:
++Options:
+   -h, --help         print this help, then exit
+   -t, --time-stamp   print date of last modification, then exit
+   -v, --version      print version number, then exit
+@@ -68,7 +76,7 @@ Report bugs and patches to <config-patches@gnu.org>."
+ version="\
+ GNU config.sub ($timestamp)
+ 
+-Copyright 1992-2015 Free Software Foundation, Inc.
++Copyright 1992-2021 Free Software Foundation, Inc.
+ 
+ This is free software; see the source for copying conditions.  There is NO
+ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+@@ -90,12 +98,12 @@ while test $# -gt 0 ; do
+     - )	# Use stdin as input.
+        break ;;
+     -* )
+-       echo "$me: invalid option $1$help"
++       echo "$me: invalid option $1$help" >&2
+        exit 1 ;;
+ 
+     *local*)
+        # First pass through any local machine types.
+-       echo $1
++       echo "$1"
+        exit ;;
+ 
+     * )
+@@ -111,1231 +119,1181 @@ case $# in
+     exit 1;;
+ esac
+ 
+-# Separate what the user gave into CPU-COMPANY and OS or KERNEL-OS (if any).
+-# Here we must recognize all the valid KERNEL-OS combinations.
+-maybe_os=`echo $1 | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\2/'`
+-case $maybe_os in
+-  nto-qnx* | linux-gnu* | linux-android* | linux-dietlibc | linux-newlib* | \
+-  linux-musl* | linux-uclibc* | uclinux-uclibc* | uclinux-gnu* | kfreebsd*-gnu* | \
+-  knetbsd*-gnu* | netbsd*-gnu* | netbsd*-eabi* | \
+-  kopensolaris*-gnu* | \
+-  storm-chaos* | os2-emx* | rtmk-nova*)
+-    os=-$maybe_os
+-    basic_machine=`echo $1 | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\1/'`
+-    ;;
+-  android-linux)
+-    os=-linux-android
+-    basic_machine=`echo $1 | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\1/'`-unknown
+-    ;;
+-  *)
+-    basic_machine=`echo $1 | sed 's/-[^-]*$//'`
+-    if [ $basic_machine != $1 ]
+-    then os=`echo $1 | sed 's/.*-/-/'`
+-    else os=; fi
+-    ;;
+-esac
++# Split fields of configuration type
++# shellcheck disable=SC2162
++saved_IFS=$IFS
++IFS="-" read field1 field2 field3 field4 <<EOF
++$1
++EOF
++IFS=$saved_IFS
+ 
+-### Let's recognize common machines as not being operating systems so
+-### that things like config.sub decstation-3100 work.  We also
+-### recognize some manufacturers as not being operating systems, so we
+-### can provide default operating systems below.
+-case $os in
+-	-sun*os*)
+-		# Prevent following clause from handling this invalid input.
+-		;;
+-	-dec* | -mips* | -sequent* | -encore* | -pc532* | -sgi* | -sony* | \
+-	-att* | -7300* | -3300* | -delta* | -motorola* | -sun[234]* | \
+-	-unicom* | -ibm* | -next | -hp | -isi* | -apollo | -altos* | \
+-	-convergent* | -ncr* | -news | -32* | -3600* | -3100* | -hitachi* |\
+-	-c[123]* | -convex* | -sun | -crds | -omron* | -dg | -ultra | -tti* | \
+-	-harris | -dolphin | -highlevel | -gould | -cbm | -ns | -masscomp | \
+-	-apple | -axis | -knuth | -cray | -microblaze*)
+-		os=
+-		basic_machine=$1
+-		;;
+-	-bluegene*)
+-		os=-cnk
+-		;;
+-	-sim | -cisco | -oki | -wec | -winbond)
+-		os=
+-		basic_machine=$1
+-		;;
+-	-scout)
+-		;;
+-	-wrs)
+-		os=-vxworks
+-		basic_machine=$1
+-		;;
+-	-chorusos*)
+-		os=-chorusos
+-		basic_machine=$1
+-		;;
+-	-chorusrdb)
+-		os=-chorusrdb
+-		basic_machine=$1
+-		;;
+-	-hiux*)
+-		os=-hiuxwe2
+-		;;
+-	-sco6)
+-		os=-sco5v6
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco5)
+-		os=-sco3.2v5
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco4)
+-		os=-sco3.2v4
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco3.2.[4-9]*)
+-		os=`echo $os | sed -e 's/sco3.2./sco3.2v/'`
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco3.2v[4-9]*)
+-		# Don't forget version if it is 3.2v4 or newer.
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco5v6*)
+-		# Don't forget version if it is 3.2v4 or newer.
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-sco*)
+-		os=-sco3.2v2
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-udk*)
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-isc)
+-		os=-isc2.2
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-clix*)
+-		basic_machine=clipper-intergraph
+-		;;
+-	-isc*)
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-pc/'`
+-		;;
+-	-lynx*178)
+-		os=-lynxos178
+-		;;
+-	-lynx*5)
+-		os=-lynxos5
+-		;;
+-	-lynx*)
+-		os=-lynxos
++# Separate into logical components for further validation
++case $1 in
++	*-*-*-*-*)
++		echo Invalid configuration \`"$1"\': more than four components >&2
++		exit 1
+ 		;;
+-	-ptx*)
+-		basic_machine=`echo $1 | sed -e 's/86-.*/86-sequent/'`
++	*-*-*-*)
++		basic_machine=$field1-$field2
++		basic_os=$field3-$field4
+ 		;;
+-	-windowsnt*)
+-		os=`echo $os | sed -e 's/windowsnt/winnt/'`
++	*-*-*)
++		# Ambiguous whether COMPANY is present, or skipped and KERNEL-OS is two
++		# parts
++		maybe_os=$field2-$field3
++		case $maybe_os in
++			nto-qnx* | linux-* | uclinux-uclibc* \
++			| uclinux-gnu* | kfreebsd*-gnu* | knetbsd*-gnu* | netbsd*-gnu* \
++			| netbsd*-eabi* | kopensolaris*-gnu* | cloudabi*-eabi* \
++			| storm-chaos* | os2-emx* | rtmk-nova*)
++				basic_machine=$field1
++				basic_os=$maybe_os
++				;;
++			android-linux)
++				basic_machine=$field1-unknown
++				basic_os=linux-android
++				;;
++			*)
++				basic_machine=$field1-$field2
++				basic_os=$field3
++				;;
++		esac
+ 		;;
+-	-psos*)
+-		os=-psos
++	*-*)
++		# A lone config we happen to match not fitting any pattern
++		case $field1-$field2 in
++			decstation-3100)
++				basic_machine=mips-dec
++				basic_os=
++				;;
++			*-*)
++				# Second component is usually, but not always the OS
++				case $field2 in
++					# Prevent following clause from handling this valid os
++					sun*os*)
++						basic_machine=$field1
++						basic_os=$field2
++						;;
++					zephyr*)
++						basic_machine=$field1-unknown
++						basic_os=$field2
++						;;
++					# Manufacturers
++					dec* | mips* | sequent* | encore* | pc533* | sgi* | sony* \
++					| att* | 7300* | 3300* | delta* | motorola* | sun[234]* \
++					| unicom* | ibm* | next | hp | isi* | apollo | altos* \
++					| convergent* | ncr* | news | 32* | 3600* | 3100* \
++					| hitachi* | c[123]* | convex* | sun | crds | omron* | dg \
++					| ultra | tti* | harris | dolphin | highlevel | gould \
++					| cbm | ns | masscomp | apple | axis | knuth | cray \
++					| microblaze* | sim | cisco \
++					| oki | wec | wrs | winbond)
++						basic_machine=$field1-$field2
++						basic_os=
++						;;
++					*)
++						basic_machine=$field1
++						basic_os=$field2
++						;;
++				esac
++			;;
++		esac
+ 		;;
+-	-mint | -mint[0-9]*)
+-		basic_machine=m68k-atari
+-		os=-mint
++	*)
++		# Convert single-component short-hands not valid as part of
++		# multi-component configurations.
++		case $field1 in
++			386bsd)
++				basic_machine=i386-pc
++				basic_os=bsd
++				;;
++			a29khif)
++				basic_machine=a29k-amd
++				basic_os=udi
++				;;
++			adobe68k)
++				basic_machine=m68010-adobe
++				basic_os=scout
++				;;
++			alliant)
++				basic_machine=fx80-alliant
++				basic_os=
++				;;
++			altos | altos3068)
++				basic_machine=m68k-altos
++				basic_os=
++				;;
++			am29k)
++				basic_machine=a29k-none
++				basic_os=bsd
++				;;
++			amdahl)
++				basic_machine=580-amdahl
++				basic_os=sysv
++				;;
++			amiga)
++				basic_machine=m68k-unknown
++				basic_os=
++				;;
++			amigaos | amigados)
++				basic_machine=m68k-unknown
++				basic_os=amigaos
++				;;
++			amigaunix | amix)
++				basic_machine=m68k-unknown
++				basic_os=sysv4
++				;;
++			apollo68)
++				basic_machine=m68k-apollo
++				basic_os=sysv
++				;;
++			apollo68bsd)
++				basic_machine=m68k-apollo
++				basic_os=bsd
++				;;
++			aros)
++				basic_machine=i386-pc
++				basic_os=aros
++				;;
++			aux)
++				basic_machine=m68k-apple
++				basic_os=aux
++				;;
++			balance)
++				basic_machine=ns32k-sequent
++				basic_os=dynix
++				;;
++			blackfin)
++				basic_machine=bfin-unknown
++				basic_os=linux
++				;;
++			cegcc)
++				basic_machine=arm-unknown
++				basic_os=cegcc
++				;;
++			convex-c1)
++				basic_machine=c1-convex
++				basic_os=bsd
++				;;
++			convex-c2)
++				basic_machine=c2-convex
++				basic_os=bsd
++				;;
++			convex-c32)
++				basic_machine=c32-convex
++				basic_os=bsd
++				;;
++			convex-c34)
++				basic_machine=c34-convex
++				basic_os=bsd
++				;;
++			convex-c38)
++				basic_machine=c38-convex
++				basic_os=bsd
++				;;
++			cray)
++				basic_machine=j90-cray
++				basic_os=unicos
++				;;
++			crds | unos)
++				basic_machine=m68k-crds
++				basic_os=
++				;;
++			da30)
++				basic_machine=m68k-da30
++				basic_os=
++				;;
++			decstation | pmax | pmin | dec3100 | decstatn)
++				basic_machine=mips-dec
++				basic_os=
++				;;
++			delta88)
++				basic_machine=m88k-motorola
++				basic_os=sysv3
++				;;
++			dicos)
++				basic_machine=i686-pc
++				basic_os=dicos
++				;;
++			djgpp)
++				basic_machine=i586-pc
++				basic_os=msdosdjgpp
++				;;
++			ebmon29k)
++				basic_machine=a29k-amd
++				basic_os=ebmon
++				;;
++			es1800 | OSE68k | ose68k | ose | OSE)
++				basic_machine=m68k-ericsson
++				basic_os=ose
++				;;
++			gmicro)
++				basic_machine=tron-gmicro
++				basic_os=sysv
++				;;
++			go32)
++				basic_machine=i386-pc
++				basic_os=go32
++				;;
++			h8300hms)
++				basic_machine=h8300-hitachi
++				basic_os=hms
++				;;
++			h8300xray)
++				basic_machine=h8300-hitachi
++				basic_os=xray
++				;;
++			h8500hms)
++				basic_machine=h8500-hitachi
++				basic_os=hms
++				;;
++			harris)
++				basic_machine=m88k-harris
++				basic_os=sysv3
++				;;
++			hp300 | hp300hpux)
++				basic_machine=m68k-hp
++				basic_os=hpux
++				;;
++			hp300bsd)
++				basic_machine=m68k-hp
++				basic_os=bsd
++				;;
++			hppaosf)
++				basic_machine=hppa1.1-hp
++				basic_os=osf
++				;;
++			hppro)
++				basic_machine=hppa1.1-hp
++				basic_os=proelf
++				;;
++			i386mach)
++				basic_machine=i386-mach
++				basic_os=mach
++				;;
++			isi68 | isi)
++				basic_machine=m68k-isi
++				basic_os=sysv
++				;;
++			m68knommu)
++				basic_machine=m68k-unknown
++				basic_os=linux
++				;;
++			magnum | m3230)
++				basic_machine=mips-mips
++				basic_os=sysv
++				;;
++			merlin)
++				basic_machine=ns32k-utek
++				basic_os=sysv
++				;;
++			mingw64)
++				basic_machine=x86_64-pc
++				basic_os=mingw64
++				;;
++			mingw32)
++				basic_machine=i686-pc
++				basic_os=mingw32
++				;;
++			mingw32ce)
++				basic_machine=arm-unknown
++				basic_os=mingw32ce
++				;;
++			monitor)
++				basic_machine=m68k-rom68k
++				basic_os=coff
++				;;
++			morphos)
++				basic_machine=powerpc-unknown
++				basic_os=morphos
++				;;
++			moxiebox)
++				basic_machine=moxie-unknown
++				basic_os=moxiebox
++				;;
++			msdos)
++				basic_machine=i386-pc
++				basic_os=msdos
++				;;
++			msys)
++				basic_machine=i686-pc
++				basic_os=msys
++				;;
++			mvs)
++				basic_machine=i370-ibm
++				basic_os=mvs
++				;;
++			nacl)
++				basic_machine=le32-unknown
++				basic_os=nacl
++				;;
++			ncr3000)
++				basic_machine=i486-ncr
++				basic_os=sysv4
++				;;
++			netbsd386)
++				basic_machine=i386-pc
++				basic_os=netbsd
++				;;
++			netwinder)
++				basic_machine=armv4l-rebel
++				basic_os=linux
++				;;
++			news | news700 | news800 | news900)
++				basic_machine=m68k-sony
++				basic_os=newsos
++				;;
++			news1000)
++				basic_machine=m68030-sony
++				basic_os=newsos
++				;;
++			necv70)
++				basic_machine=v70-nec
++				basic_os=sysv
++				;;
++			nh3000)
++				basic_machine=m68k-harris
++				basic_os=cxux
++				;;
++			nh[45]000)
++				basic_machine=m88k-harris
++				basic_os=cxux
++				;;
++			nindy960)
++				basic_machine=i960-intel
++				basic_os=nindy
++				;;
++			mon960)
++				basic_machine=i960-intel
++				basic_os=mon960
++				;;
++			nonstopux)
++				basic_machine=mips-compaq
++				basic_os=nonstopux
++				;;
++			os400)
++				basic_machine=powerpc-ibm
++				basic_os=os400
++				;;
++			OSE68000 | ose68000)
++				basic_machine=m68000-ericsson
++				basic_os=ose
++				;;
++			os68k)
++				basic_machine=m68k-none
++				basic_os=os68k
++				;;
++			paragon)
++				basic_machine=i860-intel
++				basic_os=osf
++				;;
++			parisc)
++				basic_machine=hppa-unknown
++				basic_os=linux
++				;;
++			psp)
++				basic_machine=mipsallegrexel-sony
++				basic_os=psp
++				;;
++			pw32)
++				basic_machine=i586-unknown
++				basic_os=pw32
++				;;
++			rdos | rdos64)
++				basic_machine=x86_64-pc
++				basic_os=rdos
++				;;
++			rdos32)
++				basic_machine=i386-pc
++				basic_os=rdos
++				;;
++			rom68k)
++				basic_machine=m68k-rom68k
++				basic_os=coff
++				;;
++			sa29200)
++				basic_machine=a29k-amd
++				basic_os=udi
++				;;
++			sei)
++				basic_machine=mips-sei
++				basic_os=seiux
++				;;
++			sequent)
++				basic_machine=i386-sequent
++				basic_os=
++				;;
++			sps7)
++				basic_machine=m68k-bull
++				basic_os=sysv2
++				;;
++			st2000)
++				basic_machine=m68k-tandem
++				basic_os=
++				;;
++			stratus)
++				basic_machine=i860-stratus
++				basic_os=sysv4
++				;;
++			sun2)
++				basic_machine=m68000-sun
++				basic_os=
++				;;
++			sun2os3)
++				basic_machine=m68000-sun
++				basic_os=sunos3
++				;;
++			sun2os4)
++				basic_machine=m68000-sun
++				basic_os=sunos4
++				;;
++			sun3)
++				basic_machine=m68k-sun
++				basic_os=
++				;;
++			sun3os3)
++				basic_machine=m68k-sun
++				basic_os=sunos3
++				;;
++			sun3os4)
++				basic_machine=m68k-sun
++				basic_os=sunos4
++				;;
++			sun4)
++				basic_machine=sparc-sun
++				basic_os=
++				;;
++			sun4os3)
++				basic_machine=sparc-sun
++				basic_os=sunos3
++				;;
++			sun4os4)
++				basic_machine=sparc-sun
++				basic_os=sunos4
++				;;
++			sun4sol2)
++				basic_machine=sparc-sun
++				basic_os=solaris2
++				;;
++			sun386 | sun386i | roadrunner)
++				basic_machine=i386-sun
++				basic_os=
++				;;
++			sv1)
++				basic_machine=sv1-cray
++				basic_os=unicos
++				;;
++			symmetry)
++				basic_machine=i386-sequent
++				basic_os=dynix
++				;;
++			t3e)
++				basic_machine=alphaev5-cray
++				basic_os=unicos
++				;;
++			t90)
++				basic_machine=t90-cray
++				basic_os=unicos
++				;;
++			toad1)
++				basic_machine=pdp10-xkl
++				basic_os=tops20
++				;;
++			tpf)
++				basic_machine=s390x-ibm
++				basic_os=tpf
++				;;
++			udi29k)
++				basic_machine=a29k-amd
++				basic_os=udi
++				;;
++			ultra3)
++				basic_machine=a29k-nyu
++				basic_os=sym1
++				;;
++			v810 | necv810)
++				basic_machine=v810-nec
++				basic_os=none
++				;;
++			vaxv)
++				basic_machine=vax-dec
++				basic_os=sysv
++				;;
++			vms)
++				basic_machine=vax-dec
++				basic_os=vms
++				;;
++			vsta)
++				basic_machine=i386-pc
++				basic_os=vsta
++				;;
++			vxworks960)
++				basic_machine=i960-wrs
++				basic_os=vxworks
++				;;
++			vxworks68)
++				basic_machine=m68k-wrs
++				basic_os=vxworks
++				;;
++			vxworks29k)
++				basic_machine=a29k-wrs
++				basic_os=vxworks
++				;;
++			xbox)
++				basic_machine=i686-pc
++				basic_os=mingw32
++				;;
++			ymp)
++				basic_machine=ymp-cray
++				basic_os=unicos
++				;;
++			*)
++				basic_machine=$1
++				basic_os=
++				;;
++		esac
+ 		;;
+ esac
+ 
+-# Decode aliases for certain CPU-COMPANY combinations.
++# Decode 1-component or ad-hoc basic machines
+ case $basic_machine in
+-	# Recognize the basic CPU types without company name.
+-	# Some are omitted here because they have special meanings below.
+-	1750a | 580 \
+-	| a29k \
+-	| aarch64 | aarch64_be \
+-	| alpha | alphaev[4-8] | alphaev56 | alphaev6[78] | alphapca5[67] \
+-	| alpha64 | alpha64ev[4-8] | alpha64ev56 | alpha64ev6[78] | alpha64pca5[67] \
+-	| am33_2.0 \
+-	| arc | arceb \
+-	| arm | arm[bl]e | arme[lb] | armv[2-8] | armv[3-8][lb] | armv7[arm] \
+-	| avr | avr32 \
+-	| be32 | be64 \
+-	| bfin \
+-	| c4x | c8051 | clipper \
+-	| d10v | d30v | dlx | dsp16xx \
+-	| e2k | epiphany \
+-	| fido | fr30 | frv | ft32 \
+-	| h8300 | h8500 | hppa | hppa1.[01] | hppa2.0 | hppa2.0[nw] | hppa64 \
+-	| hexagon \
+-	| i370 | i860 | i960 | ia64 \
+-	| ip2k | iq2000 \
+-	| k1om \
+-	| le32 | le64 \
+-	| lm32 \
+-	| m32c | m32r | m32rle | m68000 | m68k | m88k \
+-	| maxq | mb | microblaze | microblazeel | mcore | mep | metag \
+-	| mips | mipsbe | mipseb | mipsel | mipsle \
+-	| mips16 \
+-	| mips64 | mips64el \
+-	| mips64octeon | mips64octeonel \
+-	| mips64orion | mips64orionel \
+-	| mips64r5900 | mips64r5900el \
+-	| mips64vr | mips64vrel \
+-	| mips64vr4100 | mips64vr4100el \
+-	| mips64vr4300 | mips64vr4300el \
+-	| mips64vr5000 | mips64vr5000el \
+-	| mips64vr5900 | mips64vr5900el \
+-	| mipsisa32 | mipsisa32el \
+-	| mipsisa32r2 | mipsisa32r2el \
+-	| mipsisa32r6 | mipsisa32r6el \
+-	| mipsisa64 | mipsisa64el \
+-	| mipsisa64r2 | mipsisa64r2el \
+-	| mipsisa64r6 | mipsisa64r6el \
+-	| mipsisa64sb1 | mipsisa64sb1el \
+-	| mipsisa64sr71k | mipsisa64sr71kel \
+-	| mipsr5900 | mipsr5900el \
+-	| mipstx39 | mipstx39el \
+-	| mn10200 | mn10300 \
+-	| moxie \
+-	| mt \
+-	| msp430 \
+-	| nds32 | nds32le | nds32be \
+-	| nios | nios2 | nios2eb | nios2el \
+-	| ns16k | ns32k \
+-	| open8 | or1k | or1knd | or32 \
+-	| pdp10 | pdp11 | pj | pjl \
+-	| powerpc | powerpc64 | powerpc64le | powerpcle \
+-	| pyramid \
+-	| riscv32 | riscv64 \
+-	| rl78 | rx \
+-	| score \
+-	| sh | sh[1234] | sh[24]a | sh[24]aeb | sh[23]e | sh[34]eb | sheb | shbe | shle | sh[1234]le | sh3ele \
+-	| sh64 | sh64le \
+-	| sparc | sparc64 | sparc64b | sparc64v | sparc86x | sparclet | sparclite \
+-	| sparcv8 | sparcv9 | sparcv9b | sparcv9v \
+-	| spu \
+-	| tahoe | tic4x | tic54x | tic55x | tic6x | tic80 | tron \
+-	| ubicom32 \
+-	| v850 | v850e | v850e1 | v850e2 | v850es | v850e2v3 \
+-	| visium \
+-	| we32k \
+-	| x86 | xc16x | xstormy16 | xtensa \
+-	| z8k | z80)
+-		basic_machine=$basic_machine-unknown
+-		;;
+-	c54x)
+-		basic_machine=tic54x-unknown
+-		;;
+-	c55x)
+-		basic_machine=tic55x-unknown
+-		;;
+-	c6x)
+-		basic_machine=tic6x-unknown
+-		;;
+-	leon|leon[3-9])
+-		basic_machine=sparc-$basic_machine
++	# Here we handle the default manufacturer of certain CPU types.  It is in
++	# some cases the only manufacturer, in others, it is the most popular.
++	w89k)
++		cpu=hppa1.1
++		vendor=winbond
+ 		;;
+-	m6811 | m68hc11 | m6812 | m68hc12 | m68hcs12x | nvptx | picochip)
+-		basic_machine=$basic_machine-unknown
+-		os=-none
++	op50n)
++		cpu=hppa1.1
++		vendor=oki
+ 		;;
+-	m88110 | m680[12346]0 | m683?2 | m68360 | m5200 | v70 | w65 | z8k)
++	op60c)
++		cpu=hppa1.1
++		vendor=oki
+ 		;;
+-	ms1)
+-		basic_machine=mt-unknown
++	ibm*)
++		cpu=i370
++		vendor=ibm
+ 		;;
+-
+-	strongarm | thumb | xscale)
+-		basic_machine=arm-unknown
+-		;;
+-	xgate)
+-		basic_machine=$basic_machine-unknown
+-		os=-none
++	orion105)
++		cpu=clipper
++		vendor=highlevel
+ 		;;
+-	xscaleeb)
+-		basic_machine=armeb-unknown
++	mac | mpw | mac-mpw)
++		cpu=m68k
++		vendor=apple
+ 		;;
+-
+-	xscaleel)
+-		basic_machine=armel-unknown
++	pmac | pmac-mpw)
++		cpu=powerpc
++		vendor=apple
+ 		;;
+ 
+-	# We use `pc' rather than `unknown'
+-	# because (1) that's what they normally are, and
+-	# (2) the word "unknown" tends to confuse beginning users.
+-	i*86 | x86_64)
+-	  basic_machine=$basic_machine-pc
+-	  ;;
+-	# Object if more than one company name word.
+-	*-*-*)
+-		echo Invalid configuration \`$1\': machine \`$basic_machine\' not recognized 1>&2
+-		exit 1
+-		;;
+-	# Recognize the basic CPU types with company name.
+-	580-* \
+-	| a29k-* \
+-	| aarch64-* | aarch64_be-* \
+-	| alpha-* | alphaev[4-8]-* | alphaev56-* | alphaev6[78]-* \
+-	| alpha64-* | alpha64ev[4-8]-* | alpha64ev56-* | alpha64ev6[78]-* \
+-	| alphapca5[67]-* | alpha64pca5[67]-* | arc-* | arceb-* \
+-	| arm-*  | armbe-* | armle-* | armeb-* | armv*-* \
+-	| avr-* | avr32-* \
+-	| be32-* | be64-* \
+-	| bfin-* | bs2000-* \
+-	| c[123]* | c30-* | [cjt]90-* | c4x-* \
+-	| c8051-* | clipper-* | craynv-* | cydra-* \
+-	| d10v-* | d30v-* | dlx-* \
+-	| e2k-* | elxsi-* \
+-	| f30[01]-* | f700-* | fido-* | fr30-* | frv-* | fx80-* \
+-	| h8300-* | h8500-* \
+-	| hppa-* | hppa1.[01]-* | hppa2.0-* | hppa2.0[nw]-* | hppa64-* \
+-	| hexagon-* \
+-	| i*86-* | i860-* | i960-* | ia64-* \
+-	| ip2k-* | iq2000-* \
+-	| k1om-* \
+-	| le32-* | le64-* \
+-	| lm32-* \
+-	| m32c-* | m32r-* | m32rle-* \
+-	| m68000-* | m680[012346]0-* | m68360-* | m683?2-* | m68k-* \
+-	| m88110-* | m88k-* | maxq-* | mcore-* | metag-* \
+-	| microblaze-* | microblazeel-* \
+-	| mips-* | mipsbe-* | mipseb-* | mipsel-* | mipsle-* \
+-	| mips16-* \
+-	| mips64-* | mips64el-* \
+-	| mips64octeon-* | mips64octeonel-* \
+-	| mips64orion-* | mips64orionel-* \
+-	| mips64r5900-* | mips64r5900el-* \
+-	| mips64vr-* | mips64vrel-* \
+-	| mips64vr4100-* | mips64vr4100el-* \
+-	| mips64vr4300-* | mips64vr4300el-* \
+-	| mips64vr5000-* | mips64vr5000el-* \
+-	| mips64vr5900-* | mips64vr5900el-* \
+-	| mipsisa32-* | mipsisa32el-* \
+-	| mipsisa32r2-* | mipsisa32r2el-* \
+-	| mipsisa32r6-* | mipsisa32r6el-* \
+-	| mipsisa64-* | mipsisa64el-* \
+-	| mipsisa64r2-* | mipsisa64r2el-* \
+-	| mipsisa64r6-* | mipsisa64r6el-* \
+-	| mipsisa64sb1-* | mipsisa64sb1el-* \
+-	| mipsisa64sr71k-* | mipsisa64sr71kel-* \
+-	| mipsr5900-* | mipsr5900el-* \
+-	| mipstx39-* | mipstx39el-* \
+-	| mmix-* \
+-	| mt-* \
+-	| msp430-* \
+-	| nds32-* | nds32le-* | nds32be-* \
+-	| nios-* | nios2-* | nios2eb-* | nios2el-* \
+-	| none-* | np1-* | ns16k-* | ns32k-* \
+-	| open8-* \
+-	| or1k*-* \
+-	| orion-* \
+-	| pdp10-* | pdp11-* | pj-* | pjl-* | pn-* | power-* \
+-	| powerpc-* | powerpc64-* | powerpc64le-* | powerpcle-* \
+-	| pyramid-* \
+-	| rl78-* | romp-* | rs6000-* | rx-* \
+-	| sh-* | sh[1234]-* | sh[24]a-* | sh[24]aeb-* | sh[23]e-* | sh[34]eb-* | sheb-* | shbe-* \
+-	| shle-* | sh[1234]le-* | sh3ele-* | sh64-* | sh64le-* \
+-	| sparc-* | sparc64-* | sparc64b-* | sparc64v-* | sparc86x-* | sparclet-* \
+-	| sparclite-* \
+-	| sparcv8-* | sparcv9-* | sparcv9b-* | sparcv9v-* | sv1-* | sx?-* \
+-	| tahoe-* \
+-	| tic30-* | tic4x-* | tic54x-* | tic55x-* | tic6x-* | tic80-* \
+-	| tile*-* \
+-	| tron-* \
+-	| ubicom32-* \
+-	| v850-* | v850e-* | v850e1-* | v850es-* | v850e2-* | v850e2v3-* \
+-	| vax-* \
+-	| visium-* \
+-	| we32k-* \
+-	| x86-* | x86_64-* | xc16x-* | xps100-* \
+-	| xstormy16-* | xtensa*-* \
+-	| ymp-* \
+-	| z8k-* | z80-*)
+-		;;
+-	# Recognize the basic CPU types without company name, with glob match.
+-	xtensa*)
+-		basic_machine=$basic_machine-unknown
+-		;;
+ 	# Recognize the various machine names and aliases which stand
+ 	# for a CPU type and a company and sometimes even an OS.
+-	386bsd)
+-		basic_machine=i386-unknown
+-		os=-bsd
+-		;;
+ 	3b1 | 7300 | 7300-att | att-7300 | pc7300 | safari | unixpc)
+-		basic_machine=m68000-att
++		cpu=m68000
++		vendor=att
+ 		;;
+ 	3b*)
+-		basic_machine=we32k-att
+-		;;
+-	a29khif)
+-		basic_machine=a29k-amd
+-		os=-udi
+-		;;
+-	abacus)
+-		basic_machine=abacus-unknown
+-		;;
+-	adobe68k)
+-		basic_machine=m68010-adobe
+-		os=-scout
+-		;;
+-	alliant | fx80)
+-		basic_machine=fx80-alliant
+-		;;
+-	altos | altos3068)
+-		basic_machine=m68k-altos
+-		;;
+-	am29k)
+-		basic_machine=a29k-none
+-		os=-bsd
+-		;;
+-	amd64)
+-		basic_machine=x86_64-pc
+-		;;
+-	amd64-*)
+-		basic_machine=x86_64-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	amdahl)
+-		basic_machine=580-amdahl
+-		os=-sysv
+-		;;
+-	amiga | amiga-*)
+-		basic_machine=m68k-unknown
+-		;;
+-	amigaos | amigados)
+-		basic_machine=m68k-unknown
+-		os=-amigaos
+-		;;
+-	amigaunix | amix)
+-		basic_machine=m68k-unknown
+-		os=-sysv4
+-		;;
+-	apollo68)
+-		basic_machine=m68k-apollo
+-		os=-sysv
+-		;;
+-	apollo68bsd)
+-		basic_machine=m68k-apollo
+-		os=-bsd
+-		;;
+-	aros)
+-		basic_machine=i386-pc
+-		os=-aros
+-		;;
+-        asmjs)
+-		basic_machine=asmjs-unknown
+-		;;
+-	aux)
+-		basic_machine=m68k-apple
+-		os=-aux
+-		;;
+-	balance)
+-		basic_machine=ns32k-sequent
+-		os=-dynix
+-		;;
+-	blackfin)
+-		basic_machine=bfin-unknown
+-		os=-linux
+-		;;
+-	blackfin-*)
+-		basic_machine=bfin-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		os=-linux
++		cpu=we32k
++		vendor=att
+ 		;;
+ 	bluegene*)
+-		basic_machine=powerpc-ibm
+-		os=-cnk
+-		;;
+-	c54x-*)
+-		basic_machine=tic54x-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	c55x-*)
+-		basic_machine=tic55x-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	c6x-*)
+-		basic_machine=tic6x-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	c90)
+-		basic_machine=c90-cray
+-		os=-unicos
+-		;;
+-	cegcc)
+-		basic_machine=arm-unknown
+-		os=-cegcc
+-		;;
+-	convex-c1)
+-		basic_machine=c1-convex
+-		os=-bsd
+-		;;
+-	convex-c2)
+-		basic_machine=c2-convex
+-		os=-bsd
+-		;;
+-	convex-c32)
+-		basic_machine=c32-convex
+-		os=-bsd
+-		;;
+-	convex-c34)
+-		basic_machine=c34-convex
+-		os=-bsd
+-		;;
+-	convex-c38)
+-		basic_machine=c38-convex
+-		os=-bsd
+-		;;
+-	cray | j90)
+-		basic_machine=j90-cray
+-		os=-unicos
+-		;;
+-	craynv)
+-		basic_machine=craynv-cray
+-		os=-unicosmp
+-		;;
+-	cr16 | cr16-*)
+-		basic_machine=cr16-unknown
+-		os=-elf
+-		;;
+-	crds | unos)
+-		basic_machine=m68k-crds
+-		;;
+-	crisv32 | crisv32-* | etraxfs*)
+-		basic_machine=crisv32-axis
+-		;;
+-	cris | cris-* | etrax*)
+-		basic_machine=cris-axis
+-		;;
+-	crx)
+-		basic_machine=crx-unknown
+-		os=-elf
+-		;;
+-	da30 | da30-*)
+-		basic_machine=m68k-da30
+-		;;
+-	decstation | decstation-3100 | pmax | pmax-* | pmin | dec3100 | decstatn)
+-		basic_machine=mips-dec
++		cpu=powerpc
++		vendor=ibm
++		basic_os=cnk
+ 		;;
+ 	decsystem10* | dec10*)
+-		basic_machine=pdp10-dec
+-		os=-tops10
++		cpu=pdp10
++		vendor=dec
++		basic_os=tops10
+ 		;;
+ 	decsystem20* | dec20*)
+-		basic_machine=pdp10-dec
+-		os=-tops20
++		cpu=pdp10
++		vendor=dec
++		basic_os=tops20
+ 		;;
+ 	delta | 3300 | motorola-3300 | motorola-delta \
+ 	      | 3300-motorola | delta-motorola)
+-		basic_machine=m68k-motorola
++		cpu=m68k
++		vendor=motorola
+ 		;;
+-	delta88)
+-		basic_machine=m88k-motorola
+-		os=-sysv3
+-		;;
+-	dicos)
+-		basic_machine=i686-pc
+-		os=-dicos
+-		;;
+-	djgpp)
+-		basic_machine=i586-pc
+-		os=-msdosdjgpp
+-		;;
+-	dpx20 | dpx20-*)
+-		basic_machine=rs6000-bull
+-		os=-bosx
+-		;;
+-	dpx2* | dpx2*-bull)
+-		basic_machine=m68k-bull
+-		os=-sysv3
+-		;;
+-	ebmon29k)
+-		basic_machine=a29k-amd
+-		os=-ebmon
+-		;;
+-	elxsi)
+-		basic_machine=elxsi-elxsi
+-		os=-bsd
++	dpx2*)
++		cpu=m68k
++		vendor=bull
++		basic_os=sysv3
+ 		;;
+ 	encore | umax | mmax)
+-		basic_machine=ns32k-encore
++		cpu=ns32k
++		vendor=encore
+ 		;;
+-	es1800 | OSE68k | ose68k | ose | OSE)
+-		basic_machine=m68k-ericsson
+-		os=-ose
++	elxsi)
++		cpu=elxsi
++		vendor=elxsi
++		basic_os=${basic_os:-bsd}
+ 		;;
+ 	fx2800)
+-		basic_machine=i860-alliant
++		cpu=i860
++		vendor=alliant
+ 		;;
+ 	genix)
+-		basic_machine=ns32k-ns
+-		;;
+-	gmicro)
+-		basic_machine=tron-gmicro
+-		os=-sysv
+-		;;
+-	go32)
+-		basic_machine=i386-pc
+-		os=-go32
++		cpu=ns32k
++		vendor=ns
+ 		;;
+ 	h3050r* | hiux*)
+-		basic_machine=hppa1.1-hitachi
+-		os=-hiuxwe2
+-		;;
+-	h8300hms)
+-		basic_machine=h8300-hitachi
+-		os=-hms
+-		;;
+-	h8300xray)
+-		basic_machine=h8300-hitachi
+-		os=-xray
+-		;;
+-	h8500hms)
+-		basic_machine=h8500-hitachi
+-		os=-hms
+-		;;
+-	harris)
+-		basic_machine=m88k-harris
+-		os=-sysv3
+-		;;
+-	hp300-*)
+-		basic_machine=m68k-hp
+-		;;
+-	hp300bsd)
+-		basic_machine=m68k-hp
+-		os=-bsd
+-		;;
+-	hp300hpux)
+-		basic_machine=m68k-hp
+-		os=-hpux
++		cpu=hppa1.1
++		vendor=hitachi
++		basic_os=hiuxwe2
+ 		;;
+ 	hp3k9[0-9][0-9] | hp9[0-9][0-9])
+-		basic_machine=hppa1.0-hp
++		cpu=hppa1.0
++		vendor=hp
+ 		;;
+ 	hp9k2[0-9][0-9] | hp9k31[0-9])
+-		basic_machine=m68000-hp
++		cpu=m68000
++		vendor=hp
+ 		;;
+ 	hp9k3[2-9][0-9])
+-		basic_machine=m68k-hp
++		cpu=m68k
++		vendor=hp
+ 		;;
+ 	hp9k6[0-9][0-9] | hp6[0-9][0-9])
+-		basic_machine=hppa1.0-hp
++		cpu=hppa1.0
++		vendor=hp
+ 		;;
+ 	hp9k7[0-79][0-9] | hp7[0-79][0-9])
+-		basic_machine=hppa1.1-hp
++		cpu=hppa1.1
++		vendor=hp
+ 		;;
+ 	hp9k78[0-9] | hp78[0-9])
+ 		# FIXME: really hppa2.0-hp
+-		basic_machine=hppa1.1-hp
++		cpu=hppa1.1
++		vendor=hp
+ 		;;
+ 	hp9k8[67]1 | hp8[67]1 | hp9k80[24] | hp80[24] | hp9k8[78]9 | hp8[78]9 | hp9k893 | hp893)
+ 		# FIXME: really hppa2.0-hp
+-		basic_machine=hppa1.1-hp
++		cpu=hppa1.1
++		vendor=hp
+ 		;;
+ 	hp9k8[0-9][13679] | hp8[0-9][13679])
+-		basic_machine=hppa1.1-hp
++		cpu=hppa1.1
++		vendor=hp
+ 		;;
+ 	hp9k8[0-9][0-9] | hp8[0-9][0-9])
+-		basic_machine=hppa1.0-hp
+-		;;
+-	hppa-next)
+-		os=-nextstep3
+-		;;
+-	hppaosf)
+-		basic_machine=hppa1.1-hp
+-		os=-osf
+-		;;
+-	hppro)
+-		basic_machine=hppa1.1-hp
+-		os=-proelf
+-		;;
+-	i370-ibm* | ibm*)
+-		basic_machine=i370-ibm
++		cpu=hppa1.0
++		vendor=hp
+ 		;;
+ 	i*86v32)
+-		basic_machine=`echo $1 | sed -e 's/86.*/86-pc/'`
+-		os=-sysv32
++		cpu=`echo "$1" | sed -e 's/86.*/86/'`
++		vendor=pc
++		basic_os=sysv32
+ 		;;
+ 	i*86v4*)
+-		basic_machine=`echo $1 | sed -e 's/86.*/86-pc/'`
+-		os=-sysv4
++		cpu=`echo "$1" | sed -e 's/86.*/86/'`
++		vendor=pc
++		basic_os=sysv4
+ 		;;
+ 	i*86v)
+-		basic_machine=`echo $1 | sed -e 's/86.*/86-pc/'`
+-		os=-sysv
++		cpu=`echo "$1" | sed -e 's/86.*/86/'`
++		vendor=pc
++		basic_os=sysv
+ 		;;
+ 	i*86sol2)
+-		basic_machine=`echo $1 | sed -e 's/86.*/86-pc/'`
+-		os=-solaris2
++		cpu=`echo "$1" | sed -e 's/86.*/86/'`
++		vendor=pc
++		basic_os=solaris2
+ 		;;
+-	i386mach)
+-		basic_machine=i386-mach
+-		os=-mach
+-		;;
+-	i386-vsta | vsta)
+-		basic_machine=i386-unknown
+-		os=-vsta
++	j90 | j90-cray)
++		cpu=j90
++		vendor=cray
++		basic_os=${basic_os:-unicos}
+ 		;;
+ 	iris | iris4d)
+-		basic_machine=mips-sgi
+-		case $os in
+-		    -irix*)
++		cpu=mips
++		vendor=sgi
++		case $basic_os in
++		    irix*)
+ 			;;
+ 		    *)
+-			os=-irix4
++			basic_os=irix4
+ 			;;
+ 		esac
+ 		;;
+-	isi68 | isi)
+-		basic_machine=m68k-isi
+-		os=-sysv
+-		;;
+-	leon-*|leon[3-9]-*)
+-		basic_machine=sparc-`echo $basic_machine | sed 's/-.*//'`
+-		;;
+-	m68knommu)
+-		basic_machine=m68k-unknown
+-		os=-linux
+-		;;
+-	m68knommu-*)
+-		basic_machine=m68k-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		os=-linux
+-		;;
+-	m88k-omron*)
+-		basic_machine=m88k-omron
+-		;;
+-	magnum | m3230)
+-		basic_machine=mips-mips
+-		os=-sysv
+-		;;
+-	merlin)
+-		basic_machine=ns32k-utek
+-		os=-sysv
+-		;;
+-	microblaze*)
+-		basic_machine=microblaze-xilinx
+-		;;
+-	mingw64)
+-		basic_machine=x86_64-pc
+-		os=-mingw64
+-		;;
+-	mingw32)
+-		basic_machine=i686-pc
+-		os=-mingw32
+-		;;
+-	mingw32ce)
+-		basic_machine=arm-unknown
+-		os=-mingw32ce
+-		;;
+ 	miniframe)
+-		basic_machine=m68000-convergent
+-		;;
+-	*mint | -mint[0-9]* | *MiNT | *MiNT[0-9]*)
+-		basic_machine=m68k-atari
+-		os=-mint
+-		;;
+-	mips3*-*)
+-		basic_machine=`echo $basic_machine | sed -e 's/mips3/mips64/'`
+-		;;
+-	mips3*)
+-		basic_machine=`echo $basic_machine | sed -e 's/mips3/mips64/'`-unknown
+-		;;
+-	monitor)
+-		basic_machine=m68k-rom68k
+-		os=-coff
+-		;;
+-	morphos)
+-		basic_machine=powerpc-unknown
+-		os=-morphos
+-		;;
+-	moxiebox)
+-		basic_machine=moxie-unknown
+-		os=-moxiebox
+-		;;
+-	msdos)
+-		basic_machine=i386-pc
+-		os=-msdos
+-		;;
+-	ms1-*)
+-		basic_machine=`echo $basic_machine | sed -e 's/ms1-/mt-/'`
+-		;;
+-	msys)
+-		basic_machine=i686-pc
+-		os=-msys
+-		;;
+-	mvs)
+-		basic_machine=i370-ibm
+-		os=-mvs
+-		;;
+-	nacl)
+-		basic_machine=le32-unknown
+-		os=-nacl
++		cpu=m68000
++		vendor=convergent
+ 		;;
+-	ncr3000)
+-		basic_machine=i486-ncr
+-		os=-sysv4
+-		;;
+-	netbsd386)
+-		basic_machine=i386-unknown
+-		os=-netbsd
+-		;;
+-	netwinder)
+-		basic_machine=armv4l-rebel
+-		os=-linux
+-		;;
+-	news | news700 | news800 | news900)
+-		basic_machine=m68k-sony
+-		os=-newsos
+-		;;
+-	news1000)
+-		basic_machine=m68030-sony
+-		os=-newsos
++	*mint | mint[0-9]* | *MiNT | *MiNT[0-9]*)
++		cpu=m68k
++		vendor=atari
++		basic_os=mint
+ 		;;
+ 	news-3600 | risc-news)
+-		basic_machine=mips-sony
+-		os=-newsos
+-		;;
+-	necv70)
+-		basic_machine=v70-nec
+-		os=-sysv
+-		;;
+-	next | m*-next )
+-		basic_machine=m68k-next
+-		case $os in
+-		    -nextstep* )
++		cpu=mips
++		vendor=sony
++		basic_os=newsos
++		;;
++	next | m*-next)
++		cpu=m68k
++		vendor=next
++		case $basic_os in
++		    openstep*)
++		        ;;
++		    nextstep*)
+ 			;;
+-		    -ns2*)
+-		      os=-nextstep2
++		    ns2*)
++		      basic_os=nextstep2
+ 			;;
+ 		    *)
+-		      os=-nextstep3
++		      basic_os=nextstep3
+ 			;;
+ 		esac
+ 		;;
+-	nh3000)
+-		basic_machine=m68k-harris
+-		os=-cxux
+-		;;
+-	nh[45]000)
+-		basic_machine=m88k-harris
+-		os=-cxux
+-		;;
+-	nindy960)
+-		basic_machine=i960-intel
+-		os=-nindy
+-		;;
+-	mon960)
+-		basic_machine=i960-intel
+-		os=-mon960
+-		;;
+-	nonstopux)
+-		basic_machine=mips-compaq
+-		os=-nonstopux
+-		;;
+ 	np1)
+-		basic_machine=np1-gould
+-		;;
+-	neo-tandem)
+-		basic_machine=neo-tandem
+-		;;
+-	nse-tandem)
+-		basic_machine=nse-tandem
+-		;;
+-	nsr-tandem)
+-		basic_machine=nsr-tandem
++		cpu=np1
++		vendor=gould
+ 		;;
+ 	op50n-* | op60c-*)
+-		basic_machine=hppa1.1-oki
+-		os=-proelf
+-		;;
+-	openrisc | openrisc-*)
+-		basic_machine=or32-unknown
+-		;;
+-	os400)
+-		basic_machine=powerpc-ibm
+-		os=-os400
+-		;;
+-	OSE68000 | ose68000)
+-		basic_machine=m68000-ericsson
+-		os=-ose
+-		;;
+-	os68k)
+-		basic_machine=m68k-none
+-		os=-os68k
++		cpu=hppa1.1
++		vendor=oki
++		basic_os=proelf
+ 		;;
+ 	pa-hitachi)
+-		basic_machine=hppa1.1-hitachi
+-		os=-hiuxwe2
+-		;;
+-	paragon)
+-		basic_machine=i860-intel
+-		os=-osf
+-		;;
+-	parisc)
+-		basic_machine=hppa-unknown
+-		os=-linux
+-		;;
+-	parisc-*)
+-		basic_machine=hppa-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		os=-linux
++		cpu=hppa1.1
++		vendor=hitachi
++		basic_os=hiuxwe2
+ 		;;
+ 	pbd)
+-		basic_machine=sparc-tti
++		cpu=sparc
++		vendor=tti
+ 		;;
+ 	pbb)
+-		basic_machine=m68k-tti
+-		;;
+-	pc532 | pc532-*)
+-		basic_machine=ns32k-pc532
+-		;;
+-	pc98)
+-		basic_machine=i386-pc
++		cpu=m68k
++		vendor=tti
+ 		;;
+-	pc98-*)
+-		basic_machine=i386-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	pentium | p5 | k5 | k6 | nexgen | viac3)
+-		basic_machine=i586-pc
+-		;;
+-	pentiumpro | p6 | 6x86 | athlon | athlon_*)
+-		basic_machine=i686-pc
+-		;;
+-	pentiumii | pentium2 | pentiumiii | pentium3)
+-		basic_machine=i686-pc
+-		;;
+-	pentium4)
+-		basic_machine=i786-pc
+-		;;
+-	pentium-* | p5-* | k5-* | k6-* | nexgen-* | viac3-*)
+-		basic_machine=i586-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	pentiumpro-* | p6-* | 6x86-* | athlon-*)
+-		basic_machine=i686-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	pentiumii-* | pentium2-* | pentiumiii-* | pentium3-*)
+-		basic_machine=i686-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	pentium4-*)
+-		basic_machine=i786-`echo $basic_machine | sed 's/^[^-]*-//'`
++	pc532)
++		cpu=ns32k
++		vendor=pc532
+ 		;;
+ 	pn)
+-		basic_machine=pn-gould
+-		;;
+-	power)	basic_machine=power-ibm
+-		;;
+-	ppc | ppcbe)	basic_machine=powerpc-unknown
++		cpu=pn
++		vendor=gould
+ 		;;
+-	ppc-* | ppcbe-*)
+-		basic_machine=powerpc-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	ppcle | powerpclittle | ppc-le | powerpc-little)
+-		basic_machine=powerpcle-unknown
+-		;;
+-	ppcle-* | powerpclittle-*)
+-		basic_machine=powerpcle-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	ppc64)	basic_machine=powerpc64-unknown
+-		;;
+-	ppc64-*) basic_machine=powerpc64-`echo $basic_machine | sed 's/^[^-]*-//'`
+-		;;
+-	ppc64le | powerpc64little | ppc64-le | powerpc64-little)
+-		basic_machine=powerpc64le-unknown
+-		;;
+-	ppc64le-* | powerpc64little-*)
+-		basic_machine=powerpc64le-`echo $basic_machine | sed 's/^[^-]*-//'`
++	power)
++		cpu=power
++		vendor=ibm
+ 		;;
+ 	ps2)
+-		basic_machine=i386-ibm
+-		;;
+-	pw32)
+-		basic_machine=i586-unknown
+-		os=-pw32
+-		;;
+-	rdos | rdos64)
+-		basic_machine=x86_64-pc
+-		os=-rdos
+-		;;
+-	rdos32)
+-		basic_machine=i386-pc
+-		os=-rdos
+-		;;
+-	rom68k)
+-		basic_machine=m68k-rom68k
+-		os=-coff
++		cpu=i386
++		vendor=ibm
+ 		;;
+ 	rm[46]00)
+-		basic_machine=mips-siemens
++		cpu=mips
++		vendor=siemens
+ 		;;
+ 	rtpc | rtpc-*)
+-		basic_machine=romp-ibm
+-		;;
+-	s390 | s390-*)
+-		basic_machine=s390-ibm
++		cpu=romp
++		vendor=ibm
+ 		;;
+-	s390x | s390x-*)
+-		basic_machine=s390x-ibm
+-		;;
+-	sa29200)
+-		basic_machine=a29k-amd
+-		os=-udi
+-		;;
+-	sb1)
+-		basic_machine=mipsisa64sb1-unknown
++	sde)
++		cpu=mipsisa32
++		vendor=sde
++		basic_os=${basic_os:-elf}
+ 		;;
+-	sb1el)
+-		basic_machine=mipsisa64sb1el-unknown
++	simso-wrs)
++		cpu=sparclite
++		vendor=wrs
++		basic_os=vxworks
+ 		;;
+-	sde)
+-		basic_machine=mipsisa32-sde
+-		os=-elf
++	tower | tower-32)
++		cpu=m68k
++		vendor=ncr
+ 		;;
+-	sei)
+-		basic_machine=mips-sei
+-		os=-seiux
++	vpp*|vx|vx-*)
++		cpu=f301
++		vendor=fujitsu
+ 		;;
+-	sequent)
+-		basic_machine=i386-sequent
++	w65)
++		cpu=w65
++		vendor=wdc
+ 		;;
+-	sh)
+-		basic_machine=sh-hitachi
+-		os=-hms
++	w89k-*)
++		cpu=hppa1.1
++		vendor=winbond
++		basic_os=proelf
+ 		;;
+-	sh5el)
+-		basic_machine=sh5le-unknown
++	none)
++		cpu=none
++		vendor=none
+ 		;;
+-	sh64)
+-		basic_machine=sh64-unknown
++	leon|leon[3-9])
++		cpu=sparc
++		vendor=$basic_machine
+ 		;;
+-	sparclite-wrs | simso-wrs)
+-		basic_machine=sparclite-wrs
+-		os=-vxworks
++	leon-*|leon[3-9]-*)
++		cpu=sparc
++		vendor=`echo "$basic_machine" | sed 's/-.*//'`
+ 		;;
+-	sps7)
+-		basic_machine=m68k-bull
+-		os=-sysv2
++
++	*-*)
++		# shellcheck disable=SC2162
++		saved_IFS=$IFS
++		IFS="-" read cpu vendor <<EOF
++$basic_machine
++EOF
++		IFS=$saved_IFS
+ 		;;
+-	spur)
+-		basic_machine=spur-unknown
++	# We use `pc' rather than `unknown'
++	# because (1) that's what they normally are, and
++	# (2) the word "unknown" tends to confuse beginning users.
++	i*86 | x86_64)
++		cpu=$basic_machine
++		vendor=pc
+ 		;;
+-	st2000)
+-		basic_machine=m68k-tandem
++	# These rules are duplicated from below for sake of the special case above;
++	# i.e. things that normalized to x86 arches should also default to "pc"
++	pc98)
++		cpu=i386
++		vendor=pc
+ 		;;
+-	stratus)
+-		basic_machine=i860-stratus
+-		os=-sysv4
++	x64 | amd64)
++		cpu=x86_64
++		vendor=pc
+ 		;;
+-	strongarm-* | thumb-*)
+-		basic_machine=arm-`echo $basic_machine | sed 's/^[^-]*-//'`
++	# Recognize the basic CPU types without company name.
++	*)
++		cpu=$basic_machine
++		vendor=unknown
+ 		;;
+-	sun2)
+-		basic_machine=m68000-sun
++esac
++
++unset -v basic_machine
++
++# Decode basic machines in the full and proper CPU-Company form.
++case $cpu-$vendor in
++	# Here we handle the default manufacturer of certain CPU types in canonical form. It is in
++	# some cases the only manufacturer, in others, it is the most popular.
++	craynv-unknown)
++		vendor=cray
++		basic_os=${basic_os:-unicosmp}
+ 		;;
+-	sun2os3)
+-		basic_machine=m68000-sun
+-		os=-sunos3
++	c90-unknown | c90-cray)
++		vendor=cray
++		basic_os=${Basic_os:-unicos}
+ 		;;
+-	sun2os4)
+-		basic_machine=m68000-sun
+-		os=-sunos4
++	fx80-unknown)
++		vendor=alliant
+ 		;;
+-	sun3os3)
+-		basic_machine=m68k-sun
+-		os=-sunos3
++	romp-unknown)
++		vendor=ibm
+ 		;;
+-	sun3os4)
+-		basic_machine=m68k-sun
+-		os=-sunos4
++	mmix-unknown)
++		vendor=knuth
+ 		;;
+-	sun4os3)
+-		basic_machine=sparc-sun
+-		os=-sunos3
++	microblaze-unknown | microblazeel-unknown)
++		vendor=xilinx
+ 		;;
+-	sun4os4)
+-		basic_machine=sparc-sun
+-		os=-sunos4
++	rs6000-unknown)
++		vendor=ibm
+ 		;;
+-	sun4sol2)
+-		basic_machine=sparc-sun
+-		os=-solaris2
++	vax-unknown)
++		vendor=dec
+ 		;;
+-	sun3 | sun3-*)
+-		basic_machine=m68k-sun
++	pdp11-unknown)
++		vendor=dec
+ 		;;
+-	sun4)
+-		basic_machine=sparc-sun
++	we32k-unknown)
++		vendor=att
+ 		;;
+-	sun386 | sun386i | roadrunner)
+-		basic_machine=i386-sun
++	cydra-unknown)
++		vendor=cydrome
+ 		;;
+-	sv1)
+-		basic_machine=sv1-cray
+-		os=-unicos
++	i370-ibm*)
++		vendor=ibm
+ 		;;
+-	symmetry)
+-		basic_machine=i386-sequent
+-		os=-dynix
++	orion-unknown)
++		vendor=highlevel
+ 		;;
+-	t3e)
+-		basic_machine=alphaev5-cray
+-		os=-unicos
++	xps-unknown | xps100-unknown)
++		cpu=xps100
++		vendor=honeywell
+ 		;;
+-	t90)
+-		basic_machine=t90-cray
+-		os=-unicos
++
++	# Here we normalize CPU types with a missing or matching vendor
++	dpx20-unknown | dpx20-bull)
++		cpu=rs6000
++		vendor=bull
++		basic_os=${basic_os:-bosx}
+ 		;;
+-	tile*)
+-		basic_machine=$basic_machine-unknown
+-		os=-linux-gnu
++
++	# Here we normalize CPU types irrespective of the vendor
++	amd64-*)
++		cpu=x86_64
+ 		;;
+-	tx39)
+-		basic_machine=mipstx39-unknown
++	blackfin-*)
++		cpu=bfin
++		basic_os=linux
+ 		;;
+-	tx39el)
+-		basic_machine=mipstx39el-unknown
++	c54x-*)
++		cpu=tic54x
+ 		;;
+-	toad1)
+-		basic_machine=pdp10-xkl
+-		os=-tops20
++	c55x-*)
++		cpu=tic55x
+ 		;;
+-	tower | tower-32)
+-		basic_machine=m68k-ncr
++	c6x-*)
++		cpu=tic6x
+ 		;;
+-	tpf)
+-		basic_machine=s390x-ibm
+-		os=-tpf
++	e500v[12]-*)
++		cpu=powerpc
++		basic_os=${basic_os}"spe"
+ 		;;
+-	udi29k)
+-		basic_machine=a29k-amd
+-		os=-udi
++	mips3*-*)
++		cpu=mips64
+ 		;;
+-	ultra3)
+-		basic_machine=a29k-nyu
+-		os=-sym1
++	ms1-*)
++		cpu=mt
+ 		;;
+-	v810 | necv810)
+-		basic_machine=v810-nec
+-		os=-none
++	m68knommu-*)
++		cpu=m68k
++		basic_os=linux
+ 		;;
+-	vaxv)
+-		basic_machine=vax-dec
+-		os=-sysv
++	m9s12z-* | m68hcs12z-* | hcs12z-* | s12z-*)
++		cpu=s12z
+ 		;;
+-	vms)
+-		basic_machine=vax-dec
+-		os=-vms
++	openrisc-*)
++		cpu=or32
+ 		;;
+-	vpp*|vx|vx-*)
+-		basic_machine=f301-fujitsu
++	parisc-*)
++		cpu=hppa
++		basic_os=linux
+ 		;;
+-	vxworks960)
+-		basic_machine=i960-wrs
+-		os=-vxworks
++	pentium-* | p5-* | k5-* | k6-* | nexgen-* | viac3-*)
++		cpu=i586
+ 		;;
+-	vxworks68)
+-		basic_machine=m68k-wrs
+-		os=-vxworks
++	pentiumpro-* | p6-* | 6x86-* | athlon-* | athalon_*-*)
++		cpu=i686
+ 		;;
+-	vxworks29k)
+-		basic_machine=a29k-wrs
+-		os=-vxworks
++	pentiumii-* | pentium2-* | pentiumiii-* | pentium3-*)
++		cpu=i686
+ 		;;
+-	w65*)
+-		basic_machine=w65-wdc
+-		os=-none
++	pentium4-*)
++		cpu=i786
+ 		;;
+-	w89k-*)
+-		basic_machine=hppa1.1-winbond
+-		os=-proelf
++	pc98-*)
++		cpu=i386
+ 		;;
+-	xbox)
+-		basic_machine=i686-pc
+-		os=-mingw32
++	ppc-* | ppcbe-*)
++		cpu=powerpc
+ 		;;
+-	xps | xps100)
+-		basic_machine=xps100-honeywell
++	ppcle-* | powerpclittle-*)
++		cpu=powerpcle
+ 		;;
+-	xscale-* | xscalee[bl]-*)
+-		basic_machine=`echo $basic_machine | sed 's/^xscale/arm/'`
++	ppc64-*)
++		cpu=powerpc64
+ 		;;
+-	ymp)
+-		basic_machine=ymp-cray
+-		os=-unicos
++	ppc64le-* | powerpc64little-*)
++		cpu=powerpc64le
+ 		;;
+-	z8k-*-coff)
+-		basic_machine=z8k-unknown
+-		os=-sim
++	sb1-*)
++		cpu=mipsisa64sb1
+ 		;;
+-	z80-*-coff)
+-		basic_machine=z80-unknown
+-		os=-sim
++	sb1el-*)
++		cpu=mipsisa64sb1el
+ 		;;
+-	none)
+-		basic_machine=none-none
+-		os=-none
++	sh5e[lb]-*)
++		cpu=`echo "$cpu" | sed 's/^\(sh.\)e\(.\)$/\1\2e/'`
+ 		;;
+-
+-# Here we handle the default manufacturer of certain CPU types.  It is in
+-# some cases the only manufacturer, in others, it is the most popular.
+-	w89k)
+-		basic_machine=hppa1.1-winbond
++	spur-*)
++		cpu=spur
+ 		;;
+-	op50n)
+-		basic_machine=hppa1.1-oki
++	strongarm-* | thumb-*)
++		cpu=arm
+ 		;;
+-	op60c)
+-		basic_machine=hppa1.1-oki
++	tx39-*)
++		cpu=mipstx39
+ 		;;
+-	romp)
+-		basic_machine=romp-ibm
++	tx39el-*)
++		cpu=mipstx39el
+ 		;;
+-	mmix)
+-		basic_machine=mmix-knuth
++	x64-*)
++		cpu=x86_64
+ 		;;
+-	rs6000)
+-		basic_machine=rs6000-ibm
++	xscale-* | xscalee[bl]-*)
++		cpu=`echo "$cpu" | sed 's/^xscale/arm/'`
+ 		;;
+-	vax)
+-		basic_machine=vax-dec
++	arm64-*)
++		cpu=aarch64
+ 		;;
+-	pdp10)
+-		# there are many clones, so DEC is not a safe bet
+-		basic_machine=pdp10-unknown
++
++	# Recognize the canonical CPU Types that limit and/or modify the
++	# company names they are paired with.
++	cr16-*)
++		basic_os=${basic_os:-elf}
+ 		;;
+-	pdp11)
+-		basic_machine=pdp11-dec
++	crisv32-* | etraxfs*-*)
++		cpu=crisv32
++		vendor=axis
+ 		;;
+-	we32k)
+-		basic_machine=we32k-att
++	cris-* | etrax*-*)
++		cpu=cris
++		vendor=axis
+ 		;;
+-	sh[1234] | sh[24]a | sh[24]aeb | sh[34]eb | sh[1234]le | sh[23]ele)
+-		basic_machine=sh-unknown
++	crx-*)
++		basic_os=${basic_os:-elf}
+ 		;;
+-	sparc | sparcv8 | sparcv9 | sparcv9b | sparcv9v)
+-		basic_machine=sparc-sun
++	neo-tandem)
++		cpu=neo
++		vendor=tandem
+ 		;;
+-	cydra)
+-		basic_machine=cydra-cydrome
++	nse-tandem)
++		cpu=nse
++		vendor=tandem
+ 		;;
+-	orion)
+-		basic_machine=orion-highlevel
++	nsr-tandem)
++		cpu=nsr
++		vendor=tandem
+ 		;;
+-	orion105)
+-		basic_machine=clipper-highlevel
++	nsv-tandem)
++		cpu=nsv
++		vendor=tandem
+ 		;;
+-	mac | mpw | mac-mpw)
+-		basic_machine=m68k-apple
++	nsx-tandem)
++		cpu=nsx
++		vendor=tandem
+ 		;;
+-	pmac | pmac-mpw)
+-		basic_machine=powerpc-apple
++	mipsallegrexel-sony)
++		cpu=mipsallegrexel
++		vendor=sony
+ 		;;
+-	*-unknown)
+-		# Make sure to match an already-canonicalized machine name.
++	tile*-*)
++		basic_os=${basic_os:-linux-gnu}
+ 		;;
++
+ 	*)
+-		echo Invalid configuration \`$1\': machine \`$basic_machine\' not recognized 1>&2
+-		exit 1
++		# Recognize the canonical CPU types that are allowed with any
++		# company name.
++		case $cpu in
++			1750a | 580 \
++			| a29k \
++			| aarch64 | aarch64_be \
++			| abacus \
++			| alpha | alphaev[4-8] | alphaev56 | alphaev6[78] \
++			| alpha64 | alpha64ev[4-8] | alpha64ev56 | alpha64ev6[78] \
++			| alphapca5[67] | alpha64pca5[67] \
++			| am33_2.0 \
++			| amdgcn \
++			| arc | arceb | arc32 | arc64 \
++			| arm | arm[lb]e | arme[lb] | armv* \
++			| avr | avr32 \
++			| asmjs \
++			| ba \
++			| be32 | be64 \
++			| bfin | bpf | bs2000 \
++			| c[123]* | c30 | [cjt]90 | c4x \
++			| c8051 | clipper | craynv | csky | cydra \
++			| d10v | d30v | dlx | dsp16xx \
++			| e2k | elxsi | epiphany \
++			| f30[01] | f700 | fido | fr30 | frv | ft32 | fx80 \
++			| h8300 | h8500 \
++			| hppa | hppa1.[01] | hppa2.0 | hppa2.0[nw] | hppa64 \
++			| hexagon \
++			| i370 | i*86 | i860 | i960 | ia16 | ia64 \
++			| ip2k | iq2000 \
++			| k1om \
++			| le32 | le64 \
++			| lm32 \
++			| loongarch32 | loongarch64 | loongarchx32 \
++			| m32c | m32r | m32rle \
++			| m5200 | m68000 | m680[012346]0 | m68360 | m683?2 | m68k \
++			| m6811 | m68hc11 | m6812 | m68hc12 | m68hcs12x \
++			| m88110 | m88k | maxq | mb | mcore | mep | metag \
++			| microblaze | microblazeel \
++			| mips | mipsbe | mipseb | mipsel | mipsle \
++			| mips16 \
++			| mips64 | mips64eb | mips64el \
++			| mips64octeon | mips64octeonel \
++			| mips64orion | mips64orionel \
++			| mips64r5900 | mips64r5900el \
++			| mips64vr | mips64vrel \
++			| mips64vr4100 | mips64vr4100el \
++			| mips64vr4300 | mips64vr4300el \
++			| mips64vr5000 | mips64vr5000el \
++			| mips64vr5900 | mips64vr5900el \
++			| mipsisa32 | mipsisa32el \
++			| mipsisa32r2 | mipsisa32r2el \
++			| mipsisa32r3 | mipsisa32r3el \
++			| mipsisa32r5 | mipsisa32r5el \
++			| mipsisa32r6 | mipsisa32r6el \
++			| mipsisa64 | mipsisa64el \
++			| mipsisa64r2 | mipsisa64r2el \
++			| mipsisa64r3 | mipsisa64r3el \
++			| mipsisa64r5 | mipsisa64r5el \
++			| mipsisa64r6 | mipsisa64r6el \
++			| mipsisa64sb1 | mipsisa64sb1el \
++			| mipsisa64sr71k | mipsisa64sr71kel \
++			| mipsr5900 | mipsr5900el \
++			| mipstx39 | mipstx39el \
++			| mmix \
++			| mn10200 | mn10300 \
++			| moxie \
++			| mt \
++			| msp430 \
++			| nds32 | nds32le | nds32be \
++			| nfp \
++			| nios | nios2 | nios2eb | nios2el \
++			| none | np1 | ns16k | ns32k | nvptx \
++			| open8 \
++			| or1k* \
++			| or32 \
++			| orion \
++			| picochip \
++			| pdp10 | pdp11 | pj | pjl | pn | power \
++			| powerpc | powerpc64 | powerpc64le | powerpcle | powerpcspe \
++			| pru \
++			| pyramid \
++			| riscv | riscv32 | riscv32be | riscv64 | riscv64be \
++			| rl78 | romp | rs6000 | rx \
++			| s390 | s390x \
++			| score \
++			| sh | shl \
++			| sh[1234] | sh[24]a | sh[24]ae[lb] | sh[23]e | she[lb] | sh[lb]e \
++			| sh[1234]e[lb] |  sh[12345][lb]e | sh[23]ele | sh64 | sh64le \
++			| sparc | sparc64 | sparc64b | sparc64v | sparc86x | sparclet \
++			| sparclite \
++			| sparcv8 | sparcv9 | sparcv9b | sparcv9v | sv1 | sx* \
++			| spu \
++			| tahoe \
++			| thumbv7* \
++			| tic30 | tic4x | tic54x | tic55x | tic6x | tic80 \
++			| tron \
++			| ubicom32 \
++			| v70 | v850 | v850e | v850e1 | v850es | v850e2 | v850e2v3 \
++			| vax \
++			| visium \
++			| w65 \
++			| wasm32 | wasm64 \
++			| we32k \
++			| x86 | x86_64 | xc16x | xgate | xps100 \
++			| xstormy16 | xtensa* \
++			| ymp \
++			| z8k | z80)
++				;;
++
++			*)
++				echo Invalid configuration \`"$1"\': machine \`"$cpu-$vendor"\' not recognized 1>&2
++				exit 1
++				;;
++		esac
+ 		;;
+ esac
+ 
+ # Here we canonicalize certain aliases for manufacturers.
+-case $basic_machine in
+-	*-digital*)
+-		basic_machine=`echo $basic_machine | sed 's/digital.*/dec/'`
++case $vendor in
++	digital*)
++		vendor=dec
+ 		;;
+-	*-commodore*)
+-		basic_machine=`echo $basic_machine | sed 's/commodore.*/cbm/'`
++	commodore*)
++		vendor=cbm
+ 		;;
+ 	*)
+ 		;;
+@@ -1343,200 +1301,215 @@ esac
+ 
+ # Decode manufacturer-specific aliases for certain operating systems.
+ 
+-if [ x"$os" != x"" ]
++if test x$basic_os != x
+ then
++
++# First recognize some ad-hoc caes, or perhaps split kernel-os, or else just
++# set os.
++case $basic_os in
++	gnu/linux*)
++		kernel=linux
++		os=`echo "$basic_os" | sed -e 's|gnu/linux|gnu|'`
++		;;
++	os2-emx)
++		kernel=os2
++		os=`echo "$basic_os" | sed -e 's|os2-emx|emx|'`
++		;;
++	nto-qnx*)
++		kernel=nto
++		os=`echo "$basic_os" | sed -e 's|nto-qnx|qnx|'`
++		;;
++	*-*)
++		# shellcheck disable=SC2162
++		saved_IFS=$IFS
++		IFS="-" read kernel os <<EOF
++$basic_os
++EOF
++		IFS=$saved_IFS
++		;;
++	# Default OS when just kernel was specified
++	nto*)
++		kernel=nto
++		os=`echo "$basic_os" | sed -e 's|nto|qnx|'`
++		;;
++	linux*)
++		kernel=linux
++		os=`echo "$basic_os" | sed -e 's|linux|gnu|'`
++		;;
++	*)
++		kernel=
++		os=$basic_os
++		;;
++esac
++
++# Now, normalize the OS (knowing we just have one component, it's not a kernel,
++# etc.)
+ case $os in
+-	# First match some system type aliases
+-	# that might get confused with valid system types.
+-	# -solaris* is a basic system type, with this one exception.
+-	-auroraux)
+-		os=-auroraux
++	# First match some system type aliases that might get confused
++	# with valid system types.
++	# solaris* is a basic system type, with this one exception.
++	auroraux)
++		os=auroraux
+ 		;;
+-	-solaris1 | -solaris1.*)
+-		os=`echo $os | sed -e 's|solaris1|sunos4|'`
++	bluegene*)
++		os=cnk
+ 		;;
+-	-solaris)
+-		os=-solaris2
++	solaris1 | solaris1.*)
++		os=`echo "$os" | sed -e 's|solaris1|sunos4|'`
+ 		;;
+-	-svr4*)
+-		os=-sysv4
++	solaris)
++		os=solaris2
+ 		;;
+-	-unixware*)
+-		os=-sysv4.2uw
++	unixware*)
++		os=sysv4.2uw
+ 		;;
+-	-gnu/linux*)
+-		os=`echo $os | sed -e 's|gnu/linux|linux-gnu|'`
++	# es1800 is here to avoid being matched by es* (a different OS)
++	es1800*)
++		os=ose
+ 		;;
+-	# First accept the basic system types.
+-	# The portable systems comes first.
+-	# Each alternative MUST END IN A *, to match a version number.
+-	# -sysv* is not here because it comes later, after sysvr4.
+-	-gnu* | -bsd* | -mach* | -minix* | -genix* | -ultrix* | -irix* \
+-	      | -*vms* | -sco* | -esix* | -isc* | -aix* | -cnk* | -sunos | -sunos[34]*\
+-	      | -hpux* | -unos* | -osf* | -luna* | -dgux* | -auroraux* | -solaris* \
+-	      | -sym* | -kopensolaris* | -plan9* \
+-	      | -amigaos* | -amigados* | -msdos* | -newsos* | -unicos* | -aof* \
+-	      | -aos* | -aros* | -cloudabi* \
+-	      | -nindy* | -vxsim* | -vxworks* | -ebmon* | -hms* | -mvs* \
+-	      | -clix* | -riscos* | -uniplus* | -iris* | -rtu* | -xenix* \
+-	      | -hiux* | -386bsd* | -knetbsd* | -mirbsd* | -netbsd* \
+-	      | -bitrig* | -openbsd* | -solidbsd* \
+-	      | -ekkobsd* | -kfreebsd* | -freebsd* | -riscix* | -lynxos* \
+-	      | -bosx* | -nextstep* | -cxux* | -aout* | -elf* | -oabi* \
+-	      | -ptx* | -coff* | -ecoff* | -winnt* | -domain* | -vsta* \
+-	      | -udi* | -eabi* | -lites* | -ieee* | -go32* | -aux* \
+-	      | -chorusos* | -chorusrdb* | -cegcc* \
+-	      | -cygwin* | -msys* | -pe* | -psos* | -moss* | -proelf* | -rtems* \
+-	      | -mingw32* | -mingw64* | -linux-gnu* | -linux-android* \
+-	      | -linux-newlib* | -linux-musl* | -linux-uclibc* \
+-	      | -uxpv* | -beos* | -mpeix* | -udk* | -moxiebox* \
+-	      | -interix* | -uwin* | -mks* | -rhapsody* | -darwin* | -opened* \
+-	      | -openstep* | -oskit* | -conix* | -pw32* | -nonstopux* \
+-	      | -storm-chaos* | -tops10* | -tenex* | -tops20* | -its* \
+-	      | -os2* | -vos* | -palmos* | -uclinux* | -nucleus* \
+-	      | -morphos* | -superux* | -rtmk* | -rtmk-nova* | -windiss* \
+-	      | -powermax* | -dnix* | -nx6 | -nx7 | -sei* | -dragonfly* \
+-	      | -skyos* | -haiku* | -rdos* | -toppers* | -drops* | -es* | -tirtos*)
+-	# Remember, each alternative MUST END IN *, to match a version number.
+-		;;
+-	-qnx*)
+-		case $basic_machine in
+-		    x86-* | i*86-*)
+-			;;
+-		    *)
+-			os=-nto$os
+-			;;
+-		esac
++	# Some version numbers need modification
++	chorusos*)
++		os=chorusos
+ 		;;
+-	-nto-qnx*)
++	isc)
++		os=isc2.2
+ 		;;
+-	-nto*)
+-		os=`echo $os | sed -e 's|nto|nto-qnx|'`
++	sco6)
++		os=sco5v6
+ 		;;
+-	-sim | -es1800* | -hms* | -xray | -os68k* | -none* | -v88r* \
+-	      | -windows* | -osx | -abug | -netware* | -os9* | -beos* | -haiku* \
+-	      | -macos* | -mpw* | -magic* | -mmixware* | -mon960* | -lnews*)
++	sco5)
++		os=sco3.2v5
+ 		;;
+-	-mac*)
+-		os=`echo $os | sed -e 's|mac|macos|'`
++	sco4)
++		os=sco3.2v4
+ 		;;
+-	-linux-dietlibc)
+-		os=-linux-dietlibc
++	sco3.2.[4-9]*)
++		os=`echo "$os" | sed -e 's/sco3.2./sco3.2v/'`
+ 		;;
+-	-linux*)
+-		os=`echo $os | sed -e 's|linux|linux-gnu|'`
++	sco*v* | scout)
++		# Don't match below
+ 		;;
+-	-sunos5*)
+-		os=`echo $os | sed -e 's|sunos5|solaris2|'`
++	sco*)
++		os=sco3.2v2
+ 		;;
+-	-sunos6*)
+-		os=`echo $os | sed -e 's|sunos6|solaris3|'`
++	psos*)
++		os=psos
+ 		;;
+-	-opened*)
+-		os=-openedition
++	qnx*)
++		os=qnx
+ 		;;
+-	-os400*)
+-		os=-os400
++	hiux*)
++		os=hiuxwe2
+ 		;;
+-	-wince*)
+-		os=-wince
++	lynx*178)
++		os=lynxos178
+ 		;;
+-	-osfrose*)
+-		os=-osfrose
++	lynx*5)
++		os=lynxos5
+ 		;;
+-	-osf*)
+-		os=-osf
++	lynxos*)
++		# don't get caught up in next wildcard
+ 		;;
+-	-utek*)
+-		os=-bsd
++	lynx*)
++		os=lynxos
+ 		;;
+-	-dynix*)
+-		os=-bsd
++	mac[0-9]*)
++		os=`echo "$os" | sed -e 's|mac|macos|'`
+ 		;;
+-	-acis*)
+-		os=-aos
++	opened*)
++		os=openedition
+ 		;;
+-	-atheos*)
+-		os=-atheos
++	os400*)
++		os=os400
+ 		;;
+-	-syllable*)
+-		os=-syllable
++	sunos5*)
++		os=`echo "$os" | sed -e 's|sunos5|solaris2|'`
+ 		;;
+-	-386bsd)
+-		os=-bsd
++	sunos6*)
++		os=`echo "$os" | sed -e 's|sunos6|solaris3|'`
+ 		;;
+-	-ctix* | -uts*)
+-		os=-sysv
++	wince*)
++		os=wince
+ 		;;
+-	-nova*)
+-		os=-rtmk-nova
++	utek*)
++		os=bsd
+ 		;;
+-	-ns2 )
+-		os=-nextstep2
++	dynix*)
++		os=bsd
+ 		;;
+-	-nsk*)
+-		os=-nsk
++	acis*)
++		os=aos
+ 		;;
+-	# Preserve the version number of sinix5.
+-	-sinix5.*)
+-		os=`echo $os | sed -e 's|sinix|sysv|'`
++	atheos*)
++		os=atheos
+ 		;;
+-	-sinix*)
+-		os=-sysv4
++	syllable*)
++		os=syllable
+ 		;;
+-	-tpf*)
+-		os=-tpf
++	386bsd)
++		os=bsd
+ 		;;
+-	-triton*)
+-		os=-sysv3
++	ctix* | uts*)
++		os=sysv
+ 		;;
+-	-oss*)
+-		os=-sysv3
++	nova*)
++		os=rtmk-nova
+ 		;;
+-	-svr4)
+-		os=-sysv4
++	ns2)
++		os=nextstep2
+ 		;;
+-	-svr3)
+-		os=-sysv3
++	# Preserve the version number of sinix5.
++	sinix5.*)
++		os=`echo "$os" | sed -e 's|sinix|sysv|'`
+ 		;;
+-	-sysvr4)
+-		os=-sysv4
++	sinix*)
++		os=sysv4
+ 		;;
+-	# This must come after -sysvr4.
+-	-sysv*)
++	tpf*)
++		os=tpf
+ 		;;
+-	-ose*)
+-		os=-ose
++	triton*)
++		os=sysv3
+ 		;;
+-	-es1800*)
+-		os=-ose
++	oss*)
++		os=sysv3
+ 		;;
+-	-xenix)
+-		os=-xenix
++	svr4*)
++		os=sysv4
+ 		;;
+-	-*mint | -mint[0-9]* | -*MiNT | -MiNT[0-9]*)
+-		os=-mint
++	svr3)
++		os=sysv3
+ 		;;
+-	-aros*)
+-		os=-aros
++	sysvr4)
++		os=sysv4
+ 		;;
+-	-zvmoe)
+-		os=-zvmoe
++	ose*)
++		os=ose
+ 		;;
+-	-dicos*)
+-		os=-dicos
++	*mint | mint[0-9]* | *MiNT | MiNT[0-9]*)
++		os=mint
+ 		;;
+-	-nacl*)
++	dicos*)
++		os=dicos
+ 		;;
+-	-none)
++	pikeos*)
++		# Until real need of OS specific support for
++		# particular features comes up, bare metal
++		# configurations are quite functional.
++		case $cpu in
++		    arm*)
++			os=eabi
++			;;
++		    *)
++			os=elf
++			;;
++		esac
+ 		;;
+ 	*)
+-		# Get rid of the `-' at the beginning of $os.
+-		os=`echo $os | sed 's/[^-]*-//'`
+-		echo Invalid configuration \`$1\': system \`$os\' not recognized 1>&2
+-		exit 1
++		# No normalization, but not necessarily accepted, that comes below.
+ 		;;
+ esac
++
+ else
+ 
+ # Here we handle the default operating systems that come with various machines.
+@@ -1549,261 +1522,362 @@ else
+ # will signal an error saying that MANUFACTURER isn't an operating
+ # system, and we'll never get to this point.
+ 
+-case $basic_machine in
++kernel=
++case $cpu-$vendor in
+ 	score-*)
+-		os=-elf
++		os=elf
+ 		;;
+ 	spu-*)
+-		os=-elf
++		os=elf
+ 		;;
+ 	*-acorn)
+-		os=-riscix1.2
++		os=riscix1.2
+ 		;;
+ 	arm*-rebel)
+-		os=-linux
++		kernel=linux
++		os=gnu
+ 		;;
+ 	arm*-semi)
+-		os=-aout
++		os=aout
+ 		;;
+ 	c4x-* | tic4x-*)
+-		os=-coff
++		os=coff
+ 		;;
+ 	c8051-*)
+-		os=-elf
++		os=elf
++		;;
++	clipper-intergraph)
++		os=clix
+ 		;;
+ 	hexagon-*)
+-		os=-elf
++		os=elf
+ 		;;
+ 	tic54x-*)
+-		os=-coff
++		os=coff
+ 		;;
+ 	tic55x-*)
+-		os=-coff
++		os=coff
+ 		;;
+ 	tic6x-*)
+-		os=-coff
++		os=coff
+ 		;;
+ 	# This must come before the *-dec entry.
+ 	pdp10-*)
+-		os=-tops20
++		os=tops20
+ 		;;
+ 	pdp11-*)
+-		os=-none
++		os=none
+ 		;;
+ 	*-dec | vax-*)
+-		os=-ultrix4.2
++		os=ultrix4.2
+ 		;;
+ 	m68*-apollo)
+-		os=-domain
++		os=domain
+ 		;;
+ 	i386-sun)
+-		os=-sunos4.0.2
++		os=sunos4.0.2
+ 		;;
+ 	m68000-sun)
+-		os=-sunos3
++		os=sunos3
+ 		;;
+ 	m68*-cisco)
+-		os=-aout
++		os=aout
+ 		;;
+ 	mep-*)
+-		os=-elf
++		os=elf
+ 		;;
+ 	mips*-cisco)
+-		os=-elf
++		os=elf
+ 		;;
+ 	mips*-*)
+-		os=-elf
++		os=elf
+ 		;;
+ 	or32-*)
+-		os=-coff
++		os=coff
+ 		;;
+ 	*-tti)	# must be before sparc entry or we get the wrong os.
+-		os=-sysv3
++		os=sysv3
+ 		;;
+ 	sparc-* | *-sun)
+-		os=-sunos4.1.1
++		os=sunos4.1.1
+ 		;;
+-	*-be)
+-		os=-beos
++	pru-*)
++		os=elf
+ 		;;
+-	*-haiku)
+-		os=-haiku
++	*-be)
++		os=beos
+ 		;;
+ 	*-ibm)
+-		os=-aix
++		os=aix
+ 		;;
+ 	*-knuth)
+-		os=-mmixware
++		os=mmixware
+ 		;;
+ 	*-wec)
+-		os=-proelf
++		os=proelf
+ 		;;
+ 	*-winbond)
+-		os=-proelf
++		os=proelf
+ 		;;
+ 	*-oki)
+-		os=-proelf
++		os=proelf
+ 		;;
+ 	*-hp)
+-		os=-hpux
++		os=hpux
+ 		;;
+ 	*-hitachi)
+-		os=-hiux
++		os=hiux
+ 		;;
+ 	i860-* | *-att | *-ncr | *-altos | *-motorola | *-convergent)
+-		os=-sysv
++		os=sysv
+ 		;;
+ 	*-cbm)
+-		os=-amigaos
++		os=amigaos
+ 		;;
+ 	*-dg)
+-		os=-dgux
++		os=dgux
+ 		;;
+ 	*-dolphin)
+-		os=-sysv3
++		os=sysv3
+ 		;;
+ 	m68k-ccur)
+-		os=-rtu
++		os=rtu
+ 		;;
+ 	m88k-omron*)
+-		os=-luna
++		os=luna
+ 		;;
+-	*-next )
+-		os=-nextstep
++	*-next)
++		os=nextstep
+ 		;;
+ 	*-sequent)
+-		os=-ptx
++		os=ptx
+ 		;;
+ 	*-crds)
+-		os=-unos
++		os=unos
+ 		;;
+ 	*-ns)
+-		os=-genix
++		os=genix
+ 		;;
+ 	i370-*)
+-		os=-mvs
+-		;;
+-	*-next)
+-		os=-nextstep3
++		os=mvs
+ 		;;
+ 	*-gould)
+-		os=-sysv
++		os=sysv
+ 		;;
+ 	*-highlevel)
+-		os=-bsd
++		os=bsd
+ 		;;
+ 	*-encore)
+-		os=-bsd
++		os=bsd
+ 		;;
+ 	*-sgi)
+-		os=-irix
++		os=irix
+ 		;;
+ 	*-siemens)
+-		os=-sysv4
++		os=sysv4
+ 		;;
+ 	*-masscomp)
+-		os=-rtu
++		os=rtu
+ 		;;
+ 	f30[01]-fujitsu | f700-fujitsu)
+-		os=-uxpv
++		os=uxpv
+ 		;;
+ 	*-rom68k)
+-		os=-coff
++		os=coff
+ 		;;
+ 	*-*bug)
+-		os=-coff
++		os=coff
+ 		;;
+ 	*-apple)
+-		os=-macos
++		os=macos
+ 		;;
+ 	*-atari*)
+-		os=-mint
++		os=mint
++		;;
++	*-wrs)
++		os=vxworks
+ 		;;
+ 	*)
+-		os=-none
++		os=none
+ 		;;
+ esac
++
+ fi
+ 
++# Now, validate our (potentially fixed-up) OS.
++case $os in
++	# Sometimes we do "kernel-libc", so those need to count as OSes.
++	musl* | newlib* | relibc* | uclibc*)
++		;;
++	# Likewise for "kernel-abi"
++	eabi* | gnueabi*)
++		;;
++	# VxWorks passes extra cpu info in the 4th filed.
++	simlinux | simwindows | spe)
++		;;
++	# Now accept the basic system types.
++	# The portable systems comes first.
++	# Each alternative MUST end in a * to match a version number.
++	gnu* | android* | bsd* | mach* | minix* | genix* | ultrix* | irix* \
++	     | *vms* | esix* | aix* | cnk* | sunos | sunos[34]* \
++	     | hpux* | unos* | osf* | luna* | dgux* | auroraux* | solaris* \
++	     | sym* |  plan9* | psp* | sim* | xray* | os68k* | v88r* \
++	     | hiux* | abug | nacl* | netware* | windows* \
++	     | os9* | macos* | osx* | ios* \
++	     | mpw* | magic* | mmixware* | mon960* | lnews* \
++	     | amigaos* | amigados* | msdos* | newsos* | unicos* | aof* \
++	     | aos* | aros* | cloudabi* | sortix* | twizzler* \
++	     | nindy* | vxsim* | vxworks* | ebmon* | hms* | mvs* \
++	     | clix* | riscos* | uniplus* | iris* | isc* | rtu* | xenix* \
++	     | mirbsd* | netbsd* | dicos* | openedition* | ose* \
++	     | bitrig* | openbsd* | secbsd* | solidbsd* | libertybsd* | os108* \
++	     | ekkobsd* | freebsd* | riscix* | lynxos* | os400* \
++	     | bosx* | nextstep* | cxux* | aout* | elf* | oabi* \
++	     | ptx* | coff* | ecoff* | winnt* | domain* | vsta* \
++	     | udi* | lites* | ieee* | go32* | aux* | hcos* \
++	     | chorusrdb* | cegcc* | glidix* | serenity* \
++	     | cygwin* | msys* | pe* | moss* | proelf* | rtems* \
++	     | midipix* | mingw32* | mingw64* | mint* \
++	     | uxpv* | beos* | mpeix* | udk* | moxiebox* \
++	     | interix* | uwin* | mks* | rhapsody* | darwin* \
++	     | openstep* | oskit* | conix* | pw32* | nonstopux* \
++	     | storm-chaos* | tops10* | tenex* | tops20* | its* \
++	     | os2* | vos* | palmos* | uclinux* | nucleus* | morphos* \
++	     | scout* | superux* | sysv* | rtmk* | tpf* | windiss* \
++	     | powermax* | dnix* | nx6 | nx7 | sei* | dragonfly* \
++	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
++	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
++	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
++	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx* | zephyr*)
++		;;
++	# This one is extra strict with allowed versions
++	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)
++		# Don't forget version if it is 3.2v4 or newer.
++		;;
++	none)
++		;;
++	*)
++		echo Invalid configuration \`"$1"\': OS \`"$os"\' not recognized 1>&2
++		exit 1
++		;;
++esac
++
++# As a final step for OS-related things, validate the OS-kernel combination
++# (given a valid OS), if there is a kernel.
++case $kernel-$os in
++	linux-gnu* | linux-dietlibc* | linux-android* | linux-newlib* \
++		   | linux-musl* | linux-relibc* | linux-uclibc* )
++		;;
++	uclinux-uclibc* )
++		;;
++	-dietlibc* | -newlib* | -musl* | -relibc* | -uclibc* )
++		# These are just libc implementations, not actual OSes, and thus
++		# require a kernel.
++		echo "Invalid configuration \`$1': libc \`$os' needs explicit kernel." 1>&2
++		exit 1
++		;;
++	kfreebsd*-gnu* | kopensolaris*-gnu*)
++		;;
++	vxworks-simlinux | vxworks-simwindows | vxworks-spe)
++		;;
++	nto-qnx*)
++		;;
++	os2-emx)
++		;;
++	*-eabi* | *-gnueabi*)
++		;;
++	-*)
++		# Blank kernel with real OS is always fine.
++		;;
++	*-*)
++		echo "Invalid configuration \`$1': Kernel \`$kernel' not known to work with OS \`$os'." 1>&2
++		exit 1
++		;;
++esac
++
+ # Here we handle the case where we know the os, and the CPU type, but not the
+ # manufacturer.  We pick the logical manufacturer.
+-vendor=unknown
+-case $basic_machine in
+-	*-unknown)
+-		case $os in
+-			-riscix*)
++case $vendor in
++	unknown)
++		case $cpu-$os in
++			*-riscix*)
+ 				vendor=acorn
+ 				;;
+-			-sunos*)
++			*-sunos*)
+ 				vendor=sun
+ 				;;
+-			-cnk*|-aix*)
++			*-cnk* | *-aix*)
+ 				vendor=ibm
+ 				;;
+-			-beos*)
++			*-beos*)
+ 				vendor=be
+ 				;;
+-			-hpux*)
++			*-hpux*)
+ 				vendor=hp
+ 				;;
+-			-mpeix*)
++			*-mpeix*)
+ 				vendor=hp
+ 				;;
+-			-hiux*)
++			*-hiux*)
+ 				vendor=hitachi
+ 				;;
+-			-unos*)
++			*-unos*)
+ 				vendor=crds
+ 				;;
+-			-dgux*)
++			*-dgux*)
+ 				vendor=dg
+ 				;;
+-			-luna*)
++			*-luna*)
+ 				vendor=omron
+ 				;;
+-			-genix*)
++			*-genix*)
+ 				vendor=ns
+ 				;;
+-			-mvs* | -opened*)
++			*-clix*)
++				vendor=intergraph
++				;;
++			*-mvs* | *-opened*)
++				vendor=ibm
++				;;
++			*-os400*)
+ 				vendor=ibm
+ 				;;
+-			-os400*)
++			s390-* | s390x-*)
+ 				vendor=ibm
+ 				;;
+-			-ptx*)
++			*-ptx*)
+ 				vendor=sequent
+ 				;;
+-			-tpf*)
++			*-tpf*)
+ 				vendor=ibm
+ 				;;
+-			-vxsim* | -vxworks* | -windiss*)
++			*-vxsim* | *-vxworks* | *-windiss*)
+ 				vendor=wrs
+ 				;;
+-			-aux*)
++			*-aux*)
+ 				vendor=apple
+ 				;;
+-			-hms*)
++			*-hms*)
+ 				vendor=hitachi
+ 				;;
+-			-mpw* | -macos*)
++			*-mpw* | *-macos*)
+ 				vendor=apple
+ 				;;
+-			-*mint | -mint[0-9]* | -*MiNT | -MiNT[0-9]*)
++			*-*mint | *-mint[0-9]* | *-*MiNT | *-MiNT[0-9]*)
+ 				vendor=atari
+ 				;;
+-			-vos*)
++			*-vos*)
+ 				vendor=stratus
+ 				;;
+ 		esac
+-		basic_machine=`echo $basic_machine | sed "s/unknown/$vendor/"`
+ 		;;
+ esac
+ 
+-echo $basic_machine$os
++echo "$cpu-$vendor-${kernel:+$kernel-}$os"
+ exit
+ 
+ # Local variables:
+-# eval: (add-hook 'write-file-hooks 'time-stamp)
++# eval: (add-hook 'before-save-hook 'time-stamp)
+ # time-stamp-start: "timestamp='"
+ # time-stamp-format: "%:y-%02m-%02d"
+ # time-stamp-end: "'"

--- a/sim/icarus/meta.yaml
+++ b/sim/icarus/meta.yaml
@@ -11,6 +11,7 @@ source:
   patches:
     - fix-vvp-path.patch
     - vvp-config.patch
+    - add-arm64.patch
 
 build:
   # number: 201803050325
@@ -24,8 +25,8 @@ requirements:
   build:
     - {{ compiler('c') }}       [linux]
     - {{ compiler('cxx') }}     [linux]
-    - {{ compiler('c') }} 4.0   [osx]
-    - {{ compiler('cxx') }} 4.0 [osx]
+    - {{ compiler('c') }} 14.0   [osx]
+    - {{ compiler('cxx') }} 14.0 [osx]
     - autoconf                  [not win]
     - bison                     [not win]
     - gperf                     [not win]

--- a/syn/yosys/makefile-conda-config.patch
+++ b/syn/yosys/makefile-conda-config.patch
@@ -18,7 +18,7 @@ index ca8bc1cb5..8d7171bb0 100644
 +CXX = $(notdir $(CC))
 +LD = $(notdir $(CXX))
 +CXXFLAGS += -std=c++11 -Os
-+ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H"
++ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H -Wno-c++11-narrowing"
 +
  ifneq ($(SANITIZER),)
  $(info [Clang Sanitizer] $(SANITIZER))

--- a/syn/yosys/meta.yaml
+++ b/syn/yosys/meta.yaml
@@ -51,8 +51,8 @@ requirements:
     - make                      [not win]
     - {{ compiler('c') }}       [not osx]
     - {{ compiler('cxx') }}     [not osx]
-    - {{ compiler('c') }} 4.0   [osx]
-    - {{ compiler('cxx') }} 4.0 [osx]
+    - {{ compiler('c') }} 14.0   [osx]
+    - {{ compiler('cxx') }} 14.0 [osx]
   host:
     - m2-base 1.0.0        [win]
     - m2-bison 3.0.4       [win]


### PR DESCRIPTION
This adds support for building these packages on arm64 versions of macos.

Note that the biggest change is the clang compiler -- only clang 12 and clang 14 are available in conda, so I picked the latest available version.