### PR TITLE
misc/openlane: set openlane to be noarch

### DIFF
--- a/misc/openlane/build.sh
+++ b/misc/openlane/build.sh
@@ -20,13 +20,14 @@ set -ex
 UNAME_OUT="$(uname -s)"
 case "${UNAME_OUT}" in
     Linux*)     OS=Linux;;
+    Darwin*)    OS=Mac;;
     *)          OS="${UNAME_OUT}"
                 echo "Unknown OS: ${OS}"
                 exit;;
 esac
 
 mkdir -p $PREFIX/share/
-cp -ar $SRC_DIR $PREFIX/share/openlane
+cp -a $SRC_DIR $PREFIX/share/openlane
 # define system and pdk variables
 mkdir -p $PREFIX/share/openlane/install
 echo $PKG_VERSION-conda > $PREFIX/share/openlane/install/installed_version

--- a/misc/openlane/meta.yaml
+++ b/misc/openlane/meta.yaml
@@ -13,6 +13,7 @@ source:
     - disable-version-check.patch # conda versions differ from openlane metadata
 
 build:
+  noarch: generic
   # number: 201803050325
   number: {{ environ.get('DATE_NUM') }}
   # string: 20180305_0325


### PR DESCRIPTION
openlane is tcl scripts, so there is no reason for it to be arch-specific.