### PR TITLE
Build netgen on macos

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -350,6 +350,15 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./ci
 
+  netgen-osx:
+    runs-on: "macos-latest"
+    env:
+      PACKAGE: "misc/netgen"
+      OS_NAME: "osx"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./ci
+
   openroad-osx:
     runs-on: "macos-latest"
     env:

--- a/misc/netgen/build.sh
+++ b/misc/netgen/build.sh
@@ -7,6 +7,7 @@ set -x
 UNAME_OUT="$(uname -s)"
 case "${UNAME_OUT}" in
     Linux*)     OS=Linux;;
+    Darwin*)    OS=Mac;;
     *)          OS="${UNAME_OUT}"
                 echo "Unknown OS: ${OS}"
                 exit;;
@@ -22,12 +23,23 @@ echo "---------------------"
 
 echo CPPFLAGS="$CPPFLAGS"
 
-./configure \
-	--prefix="${PREFIX}" \
-	--with-tk="${PREFIX}" \
-	--with-tcl="${PREFIX}" \
-	--x-includes="${PREFIX}" \
-	--x-libraries="${PREFIX}"
+# Get an updated config.sub and config.guess
+cp $BUILD_PREFIX/share/autoconf/build-aux/config.* scripts
+
+if [ "$OS" = "Linux" ]; then
+	./configure \
+		--prefix="${PREFIX}" \
+		--with-tk="${PREFIX}" \
+		--with-tcl="${PREFIX}" \
+		--x-includes="${PREFIX}" \
+		--x-libraries="${PREFIX}"
+elif [ "$OS" = "Mac" ]; then
+	./configure \
+		--prefix="${PREFIX}" \
+		--with-tk="${PREFIX}" \
+		--with-tcl="${PREFIX}" \
+		--without-x
+fi
 
 echo "Configure ended with: $?"
 make V=1 -j$NUM_CORES || exit 1

--- a/misc/netgen/meta.yaml
+++ b/misc/netgen/meta.yaml
@@ -31,6 +31,10 @@ requirements:
   run:
     - python
 
+test:
+  commands:
+    - netgen -batch quit
+
 about:
   home: http://opencircuitdesign.com/netgen/
   license_file: Copying

--- a/misc/netgen/meta.yaml
+++ b/misc/netgen/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
    git_url: https://github.com/RTimothyEdwards/netgen
    git_rev: netgen-1.5
+   patches:
+     - remove-x11-requirement.patch       [osx]
 
 build:
   # number: 201803050325

--- a/misc/netgen/remove-x11-requirement.patch
+++ b/misc/netgen/remove-x11-requirement.patch
@@ -1,0 +1,38 @@
+diff --git a/scripts/configure b/scripts/configure
+index 640aa87..5c9bf35 100755
+--- a/scripts/configure
++++ b/scripts/configure
+@@ -6057,10 +6057,10 @@ if test "x$no_x" != "x"; then
+      echo Graphics options will be NULL only!
+      usingX11=
+   fi
+-  if test $usingTcl ; then
+-    echo "Cannot compile TCL version without X11, disabling."
+-    usingTcl=
+-  fi
++  # if test $usingTcl ; then
++  #   echo "Cannot compile TCL version without X11, disabling."
++  #   usingTcl=
++  # fi
+ fi
+ 
+ 
+@@ -6085,8 +6085,8 @@ fi
+ 
+ if test $usingTcl ; then
+   if test $usingX11 ; then
+-     gr_dflags="$gr_dflags -DX11 -DXLIB"
+-     gr_libs="$gr_libs -lX11"
++     gr_dflags="$gr_dflags"
++     gr_libs="$gr_libs"
+      gr_srcs="$gr_srcs \${TK_SRCS}"
+   else
+      gr_srcs="$gr_srcs \${NULL_SRCS}"
+@@ -6094,7 +6094,6 @@ if test $usingTcl ; then
+ else
+   if test $usingX11 ; then
+     gr_dflags="$gr_dflags -DX11 -DXLIB"
+-    gr_libs="$gr_libs -lX11"
+     gr_srcs="$gr_srcs \${X11_SRCS}"
+   fi
+ fi


### PR DESCRIPTION
Just disable X11, since Conda doesn't include the requisite packages.