### PR TITLE
hls/xls: bump python deps

### DIFF
--- a/hls/xls/bump-python-deps.patch
+++ b/hls/xls/bump-python-deps.patch
@@ -1,0 +1,33 @@
+diff --git a/dependency_support/pip_requirements.txt b/dependency_support/pip_requirements.txt
+index 813e1bd5..e2dca88d 100644
+--- a/dependency_support/pip_requirements.txt
++++ b/dependency_support/pip_requirements.txt
+@@ -1,16 +1,12 @@
+-Flask==2.3.2
+-Jinja2==3.1.2
+-werkzeug==2.3.3
+-itsdangerous>=2.0
+-click==8.1.3
+-markupsafe==2.1.1
+-termcolor==1.1.0
+-psutil==5.7.0
+-portpicker==1.3.1
+-pyyaml==5.4.1
+-
+-# Note: numpy and scipy version availability seems to differ between Ubuntu
+-# versions that we want to support (e.g. 18.04 vs 20.04), so we accept a
+-# range that makes successful installation on those platforms possible.
+-numpy>=1.21
+-scipy>=1.5.4,<=1.8.1
++Flask~=2.3
++Jinja2~=3.1
++Werkzeug~=2.3
++itsdangerous~=2.1
++click~=8.1
++MarkupSafe~=2.1
++termcolor~=2.3
++psutil~=5.9
++portpicker~=1.5
++PyYAML~=6.0
++numpy~=1.24
++scipy~=1.10

--- a/hls/xls/meta.yaml
+++ b/hls/xls/meta.yaml
@@ -9,7 +9,8 @@ source:
   - git_url: https://github.com/google/xls.git
     git_rev: main
     patches:
-      - use-llvm-toolchain.patch 
+      - use-llvm-toolchain.patch
+      - bump-python-deps.patch
   - url: https://github.com/bazelbuild/bazelisk/releases/download/v1.12.0/bazelisk-linux-amd64
     sha256: 6b0bcb2ea15bca16fffabe6fda75803440375354c085480fe361d2cbf32501db
 

--- a/hls/xls/test_stdlib.x
+++ b/hls/xls/test_stdlib.x
@@ -1,6 +1,6 @@
 import apfloat
 
-type F8 = apfloat::APFloat<u32:4, u32:3>;
+type F8 = apfloat::APFloat<4, 3>;
 
 #[test]
 fn cast_test() {


### PR DESCRIPTION
Should fix recent XLS build failure:
https://github.com/hdl/conda-eda/actions/runs/5127108900/jobs/9222395220

- use "compatible release" version selector, see https://peps.python.org/pep-0440/#compatible-release
- update stdlib tests to new DSLX syntax

Fixes #331 