### PR TITLE
misc/open_pdks/sky130a: use same python version as CI

### DIFF
--- a/misc/open_pdks/sky130a/meta.yaml
+++ b/misc/open_pdks/sky130a/meta.yaml
@@ -39,7 +39,7 @@ requirements:
     - automake
     - make
   host:
-    - python
+    - python 3.10
     - pip
     - typing_inspect
     - marshmallow


### PR DESCRIPTION
Fixes #329 

Also filed https://github.com/google/skywater-pdk/issues/422 to fix it properly upstream.