### PR TITLE
pnr/openroad: fix patch

### DIFF
--- a/pnr/openroad/disable-cluster-flops-cmd.patch
+++ b/pnr/openroad/disable-cluster-flops-cmd.patch
@@ -1,0 +1,154 @@
+diff --git a/src/gpl/CMakeLists.txt b/src/gpl/CMakeLists.txt
+index 86d085370..d6fd7d0d3 100644
+--- a/src/gpl/CMakeLists.txt
++++ b/src/gpl/CMakeLists.txt
+@@ -41,7 +41,6 @@ include("openroad")
+ set(THREADS_PREFER_PTHREAD_FLAG ON)
+ 
+ find_package(Eigen3 REQUIRED)
+-find_package(ortools REQUIRED)
+ find_package(LEMON NAMES LEMON lemon REQUIRED)
+ find_package(OpenMP REQUIRED)
+ 
+@@ -67,7 +66,6 @@ target_sources(gpl
+     src/timingBase.cpp
+     src/graphics.cpp
+     src/solver.cpp
+-    src/mbff.cpp
+ )
+ 
+ messages(TARGET gpl)
+@@ -87,7 +85,6 @@ target_link_libraries(gpl
+     OpenSTA
+     rsz
+     grt
+-    ortools::ortools
+     Threads::Threads
+     OpenMP::OpenMP_CXX
+ )
+diff --git a/src/gpl/README.md b/src/gpl/README.md
+index 28d40b2f6..e8ac16b3b 100644
+--- a/src/gpl/README.md
++++ b/src/gpl/README.md
+@@ -51,13 +51,6 @@ global_placement
+     [-force_cpu]
+ ```
+ 
+-```
+-cluster_flops  
+-    [-tray_weight tray_weight]  
+-    [-timing_weight timing_weight]  
+-    [-max_split_size max_split_size]  
+-```
+-
+ ### Tuning Parameters
+ 
+ - `-timing_driven`: Enable timing-driven mode
+diff --git a/src/gpl/include/gpl/Replace.h b/src/gpl/include/gpl/Replace.h
+index 3ab9e2e37..a5af2c596 100644
+--- a/src/gpl/include/gpl/Replace.h
++++ b/src/gpl/include/gpl/Replace.h
+@@ -84,7 +84,6 @@ class Replace
+ 
+   void doIncrementalPlace();
+   void doInitialPlace();
+-  void runMBFF(int max_sz, float alpha, float beta, int threads);
+ 
+   int doNesterovPlace(int start_iter = 0);
+ 
+diff --git a/src/gpl/src/replace.cpp b/src/gpl/src/replace.cpp
+index 8f645b836..8439ac17e 100644
+--- a/src/gpl/src/replace.cpp
++++ b/src/gpl/src/replace.cpp
+@@ -297,28 +297,6 @@ void Replace::doInitialPlace()
+   ip_->doBicgstabPlace();
+ }
+ 
+-void Replace::runMBFF(int max_sz, float alpha, float beta, int threads)
+-{
+-  int num_flops = 0;
+-  int num_paths = 0;
+-  vector<odb::Point> points;
+-  vector<Path> paths;
+-
+-  auto block = db_->getChip()->getBlock();
+-  for (const auto& inst : block->getInsts()) {
+-    if (inst->getMaster()->isSequential()) {
+-      int x_i, y_i;
+-      inst->getOrigin(x_i, y_i);
+-      odb::Point pt(x_i, y_i);
+-      points.push_back(pt);
+-      num_flops++;
+-    }
+-  }
+-
+-  MBFF pntset(num_flops, num_paths, points, paths, threads, 4, 10, log_);
+-  pntset.Run((max_sz == -1 ? num_flops : max_sz), alpha, beta);
+-}
+-
+ bool Replace::initNesterovPlace()
+ {
+   if (!pbc_) {
+diff --git a/src/gpl/src/replace.i b/src/gpl/src/replace.i
+index 4ecb0a32c..abf18d15c 100644
+--- a/src/gpl/src/replace.i
++++ b/src/gpl/src/replace.i
+@@ -43,16 +43,6 @@ replace_nesterov_place_cmd()
+   replace->doNesterovPlace();
+ }
+ 
+-
+-void
+-replace_run_mbff_cmd(int max_sz, float alpha, float beta) 
+-{
+-  Replace* replace = getReplace();
+-  int threads = ord::OpenRoad::openRoad()->getThreadCount();
+-  replace->runMBFF(max_sz, alpha, beta, threads);   
+-}
+-
+-
+ void
+ set_density_cmd(float density)
+ {
+diff --git a/src/gpl/src/replace.tcl b/src/gpl/src/replace.tcl
+index 5ab822570..9206e0fa5 100644
+--- a/src/gpl/src/replace.tcl
++++ b/src/gpl/src/replace.tcl
+@@ -321,37 +321,6 @@ proc global_placement { args } {
+ }
+ 
+ 
+-sta::define_cmd_args "cluster_flops" {\
+-    [-tray_weight tray_weight]\
+-    [-timing_weight timing_weight]\
+-    [-max_split_size max_split_size]\
+-}
+-
+-proc cluster_flops { args } {
+-  sta::parse_key_args "cluster_flops" args \
+-    keys { -tray_weight -timing_weight -max_split_size }
+-
+-
+-  set tray_weight 20.0
+-  set timing_weight 1.0
+-  set max_split_size -1
+-
+-  if { [info exists keys(-tray_weight)] } {
+-    set tray_weight $keys(-tray_weight)
+-  }
+-
+-  if { [info exists keys(-timing_weight)] } {
+-    set timing_weight $keys(-timing_weight)
+-  }
+-
+-  if { [info exists keys(-max_split_size)] } {
+-    set max_split_size $keys(-max_split_size)
+-  }
+-
+-  gpl::replace_run_mbff_cmd $max_split_size $tray_weight $timing_weight
+-}
+-
+-
+ namespace eval gpl {
+ proc global_placement_debug { args } {
+   sta::parse_key_args "global_placement_debug" args \

--- a/pnr/openroad/meta.yaml
+++ b/pnr/openroad/meta.yaml
@@ -15,6 +15,7 @@ source:
     patches:
       - sta-add-install-options.patch # to enable sta binary distribution
       - disable-mpl2-and-par.patch # until or-tools dep is added
+      - disable-cluster-flops-cmd.patch # until or-tools dep is added      
       - remove-boost-span-deps.patch # to allow older boost
   - url: http://lemon.cs.elte.hu/pub/sources/lemon-{{ lemon_version }}.tar.gz
     md5: {{ lemon_md5 }}

--- a/pnr/openroad/remove-boost-span-deps.patch
+++ b/pnr/openroad/remove-boost-span-deps.patch
@@ -40,7 +40,7 @@ index f2e7d900d..08cf44ee8 100644
 -
  }  // namespace odb
 diff --git a/src/utl/CMakeLists.txt b/src/utl/CMakeLists.txt
-index 85a1250d4..99e01b846 100644
+index 162e96e32..731be637d 100644
 --- a/src/utl/CMakeLists.txt
 +++ b/src/utl/CMakeLists.txt
 @@ -35,7 +35,7 @@
@@ -53,7 +53,7 @@ index 85a1250d4..99e01b846 100644
  swig_lib(NAME      utl
           NAMESPACE utl
 diff --git a/src/utl/include/utl/CFileUtils.h b/src/utl/include/utl/CFileUtils.h
-index a3c6d8024..192b1a89d 100644
+index 9864badad..d18421924 100644
 --- a/src/utl/include/utl/CFileUtils.h
 +++ b/src/utl/include/utl/CFileUtils.h
 @@ -32,7 +32,6 @@
@@ -61,10 +61,10 @@ index a3c6d8024..192b1a89d 100644
  #pragma once
  
 -#include <boost/core/span.hpp>
+ #include <cstdint>
  #include <cstdio>
  #include <string>
- 
-@@ -54,13 +53,4 @@ namespace utl {
+@@ -55,13 +54,4 @@ namespace utl {
  // logger->error is used to throw.
  std::string GetContents(FILE* file, Logger* logger);
  


### PR DESCRIPTION
refreshed the boost patch again: https://github.com/proppy/conda-eda/blob/437ca9a3fc534c82f822f3e552857453086215c0/pnr/openroad/remove-boost-span-deps.patch

@QuantamHD do you think it would be worth landing something cleaner upstream? e.g: make the dependency on boost-span optional (since it's only used in tests)