### PR TITLE
OpenROAD: Fix version string in binary

### DIFF
--- a/pnr/openroad/meta.yaml
+++ b/pnr/openroad/meta.yaml
@@ -39,13 +39,14 @@ requirements:
     - cmake >=3.19
     - swig 4.0.2
     - bison
+    - git >= 2.0          # cmake needs to be able to find git to establish a version string
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ cdt('libx11-devel') }}         # [linux]
     - {{ cdt('libxau-devel') }}         # [linux]
     - {{ cdt('libxext-devel') }}        # [linux]
     - {{ cdt('libxdamage-devel') }}     # [linux]
-    - {{ cdt('libxfixes-devel') }}     # [linux]    
+    - {{ cdt('libxfixes-devel') }}      # [linux]    
     - {{ cdt('libxxf86vm-devel') }}     # [linux]
     - {{ cdt('xorg-x11-proto-devel') }} # [linux]
     - {{ cdt('mesa-libgl-devel') }}     # [linux]


### PR DESCRIPTION
Currently  `git describe` is failing within the OpenROAD build which leads to the version number compiled into the binary falling back to a hash which doesn't work well for version checking.

https://github.com/hdl/conda-eda/actions/runs/8012258777/job/21887187187#step:5:2091
```
  23:23:44 | CMake Warning at CMakeLists.txt:98 (message):
  23:23:44 |   OpenROAD git describe failed, using sha1 instead
```

The reson seems to be that cmake is called with `-DCMAKE_FIND_ROOT_PATH` such that `find_package(Git)` fails. Easiest solution seems to be to just add git to the build requirements, which this patch does. Alternatively we could probably pass `GIT_EXECUTABLE` to cmake.

Fix https://github.com/hdl/conda-eda/issues/365