### PR TITLE
OpenROAD: Do not ignore run_export from fmt

### DIFF
--- a/pnr/openroad/meta.yaml
+++ b/pnr/openroad/meta.yaml
@@ -31,7 +31,6 @@ build:
     - CI
   ignore_run_exports_from:
     # header-only libraries
-    - fmt
 
 requirements:
   build:


### PR DESCRIPTION
It seems like on Ubuntu 20.04 (reported here https://github.com/hdl/conda-eda/issues/360) and CentOS 7 (tested by me), we have to manually `conda install fmt` for the OpenROAD binary from our package to work.

I'm not sure this will fix it but maybe we should try removing `fmt` from `ignore_run_exports_from`?

Fix https://github.com/hdl/conda-eda/issues/360 (hopefully)