### PR TITLE
sv2v: remove stack version upper bound

### DIFF
--- a/sv-front/zachjs-sv2v/meta.yaml
+++ b/sv-front/zachjs-sv2v/meta.yaml
@@ -25,7 +25,7 @@ requirements:
 # Therefore linker and `libgmp` have to be installed in the
 # OS (Conda `ld` doesn't work with OS-installed `libgmp`).
     - make
-    - stack<2.5.1
+    - stack
 
 test:
   commands:


### PR DESCRIPTION
`stack` version 2.5 doesn't support the default version of GHC now used to build sv2v. This change attempts to fix the build of sv2v by removing the included `stack` version upper bound.